### PR TITLE
Implement/Refactor lineup functionalities

### DIFF
--- a/src/caches/games.ts
+++ b/src/caches/games.ts
@@ -1,6 +1,5 @@
 import { Client, Message } from "discord.js";
-import { Games } from "../models";
-import { Game } from "../models/game";
+import { Games, Game } from "../models";
 import { sendErrorMessage, sendMessage } from "../utils";
 
 export default class GamesCache {

--- a/src/caches/games.ts
+++ b/src/caches/games.ts
@@ -110,21 +110,11 @@ export default class GamesCache {
     /**
      * Function to handle `.game remove <name>`
      * Remove a game from the cache and database
-     * @param bot - for sending error messages
-     * @param message - for replying to the original message
      * @param name - name of the game
      */
     removeGame(
-        bot : Client,
-        message : Message,
         name : string,
-    ) : void {
-        Games.deleteOne({ name })
-            .then(() => {
-                this.gamesMap.delete(name);
-                this.gameNames.delete(name);
-                sendMessage(message.channel, 'Game deleted.');
-            })
-            .catch(error => sendErrorMessage(bot, error));
+    ) : Promise<{ ok?: number; n?: number; } & { deletedCount?: number; }> {
+        return Games.deleteOne({ name }).exec();
     }
 };

--- a/src/caches/games.ts
+++ b/src/caches/games.ts
@@ -3,8 +3,8 @@ import { Games, Game } from "../models";
 import { sendErrorMessage, sendMessage } from "../utils";
 
 export default class GamesCache {
-    gamesMap: Map<string, Game>;
-    gameNames: Set<string>;
+    private gamesMap: Map<string, Game>;
+    private gameNames: Set<string>;
 
     constructor() {
         this.gamesMap = new Map<string, Game>();

--- a/src/caches/games.ts
+++ b/src/caches/games.ts
@@ -13,23 +13,24 @@ export default class GamesCache {
     }
 
     /**
-     * @returns An array of strings with the list of the names of the games
-     */
-    getGameNames() : Array<string> {
-        return Array(...this.gameNames);
-    }
-
-    /**
      * Fetch games data from the database to save in the local cache
      */
-    fetch() : void {
-        Games.find({}).exec().then((data) => {
+    fetch() : Promise<void> {
+        return Games.find({}).exec().then((data) => {
             data.forEach((game) => {
                 const name = game.name;
                 this.gamesMap.set(name, game);
                 this.gameNames.add(name);
             });
         });
+    }
+
+    /**
+     * Get a deep copy of the list of game names stored in the games cache.
+     * @returns An array of strings with the list of the names of the games
+     */
+    getGameNames() : Array<string> {
+        return Array(...this.gameNames);
     }
 
     /**

--- a/src/caches/games.ts
+++ b/src/caches/games.ts
@@ -25,6 +25,15 @@ export default class GamesCache {
     }
 
     /**
+     * Get a copy of the data of a game
+     * @param name - name of the game
+     */
+    getGame(name : string) : Game {
+        const gameData = this.gamesMap.get(name);
+        return JSON.parse(JSON.stringify(gameData)) as Game;
+    }
+
+    /**
      * Get a deep copy of the list of game names stored in the games cache.
      * @returns An array of strings with the list of the names of the games
      */

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -112,6 +112,15 @@ export default class LineupsCache {
     }
 
     /**
+     * Removes a user from the specified lineups
+     * @param gameNames - game names of the specified lineups
+     * @param user - user id to be removed from the lineups
+     */
+    leaveLineups = (names : Array<string>, user : string) : void => {
+        names.forEach((name) => this.lineups.get(name).delete(user));
+    }
+
+    /**
      * Reset all lineups
      */
     resetAllLineups() : void {

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -147,7 +147,7 @@ export default class LineupsCache {
     removeUsers(
         gameName : string, users : Array<string>,
     ) : Promise<ILineup & Document<any, any, ILineup>> {
-        const lineup = this.lineups.get(gameName).deleteUsers(users);
+        this.lineups.get(gameName).deleteUsers(users);
         return Lineups.findOneAndUpdate(
             { gameName },
             { users: this.lineups.get(gameName).getUsers() }
@@ -159,8 +159,16 @@ export default class LineupsCache {
      * @param gameNames - game names of the specified lineups
      * @param user - user id to be removed from the lineups
      */
-    leaveLineups = (gameNames : Array<string>, user : string) : void => {
+    leaveLineups = (
+        gameNames : Array<string>, user : string,
+    ) : Promise<(ILineup & Document<any, any, ILineup>)[]> => {
         gameNames.forEach((gameName) => this.lineups.get(gameName).deleteUser(user));
+        return Promise.all(gameNames.map((gameName) => {
+            return Lineups.findOneAndUpdate(
+                { gameName },
+                { users: this.lineups.get(gameName).getUsers() },
+            ).exec()
+        }));
     }
 
     /**

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -1,21 +1,37 @@
 export default class LineupsCache {
-    lineups: object;
+    lineups: Map<string, Array<Array<string>>>;
 
     constructor() {
-        this.lineups = {};
+        this.lineups = new Map<string, Array<Array<string>>>();
     }
 
-    initialize = (gameNames : string[]) => {
+    initialize = (gameNames : Array<string>) => {
         gameNames.forEach((name) => {
-            this.lineups[name] = [];
+            this.lineups.set(name, []);
         });
-    }
-
-    reset = () => {
-        this.initialize(Object.keys(this.lineups));
     }
 
     fetch = () : void => {
         // TODO: Fetch Lineups
+    }
+
+    resetAllLineups = () => {
+        // TODO: Add role validation and/or a voting check
+        Array(...this.lineups.keys()).forEach((gameName) => this.lineups.set(gameName, []));
+    }
+
+    /**
+     * Get a deep copy of the list of lineups stored in the lineups cache.
+     * @returns List of lineups per game
+     */
+    getLineups() : Map<string, Array<Array<string>>> {
+        const lineupsCopy = new Map<string, Array<Array<string>>>();
+        this.lineups.forEach((gameLineups, gameName) => {
+            lineupsCopy.set(
+                gameName,
+                gameLineups.map((gameLineup) => gameLineup.slice()),
+            );
+        });
+        return lineupsCopy;
     }
 };

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -5,7 +5,7 @@ export default class LineupsCache {
         this.lineups = new Map<string, Array<Array<string>>>();
     }
 
-    initialize = (gameNames : Array<string>) => {
+    initialize = (gameNames : Array<string>) : void => {
         gameNames.forEach((name) => {
             this.lineups.set(name, []);
         });
@@ -13,11 +13,6 @@ export default class LineupsCache {
 
     fetch = () : void => {
         // TODO: Fetch Lineups
-    }
-
-    resetAllLineups = () => {
-        // TODO: Add role validation and/or a voting check
-        Array(...this.lineups.keys()).forEach((gameName) => this.lineups.set(gameName, []));
     }
 
     /**
@@ -33,5 +28,17 @@ export default class LineupsCache {
             );
         });
         return lineupsCopy;
+    }
+
+    /**
+     * Removes a lineup from the map ie. when a game is deleted.
+     */
+    removeLineup = (name : string) : void => {
+        this.lineups.delete(name);
+    }
+
+    resetAllLineups = () : void => {
+        // TODO: Add role validation and/or a voting check
+        Array(...this.lineups.keys()).forEach((gameName) => this.lineups.set(gameName, []));
     }
 };

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -47,13 +47,13 @@ export default class LineupsCache {
 
     /**
      * Get a specific list of lineups
-     * @param names - list of names of game lineups to fetch
+     * @param gameNames - list of names of game lineups to fetch
      * @returns List of lineups per game
      */
-    getFilteredLineups(names : Array<string>) : Map<string, Array<string>> {
+    getFilteredLineups(gameNames : Array<string>) : Map<string, Array<string>> {
         const filteredLineups = new Map<string, Array<string>>();
         this.lineups.forEach((lineup, gameName) => {
-            if (names.includes(gameName)) {
+            if (gameNames.includes(gameName)) {
                 filteredLineups.set(gameName, Array(...lineup));
             }
         })

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -98,7 +98,14 @@ export default class LineupsCache {
      * Reset all lineups
      */
     resetAllLineups() : void {
-        // TODO: Add role validation and/or a voting check
         this.lineups.forEach((lineup) => lineup.clear());
+    }
+
+    /**
+     * Reset specified lineups
+     * @param names - list of names of game lineups to be reset
+     */
+    resetLineups(names : Array<string>) : void {
+        names.forEach((name) => this.lineups.get(name).clear());
     }
 };

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -1,11 +1,10 @@
-import { Client, Message } from 'discord.js';
-import { sendMessage } from '../utils';
+import { Lineup } from '../models';
 
 export default class LineupsCache {
-    private lineups: Map<string, Set<string>>;
+    private lineups: Map<string, Lineup>;
 
     constructor() {
-        this.lineups = new Map<string, Set<string>>();
+        this.lineups = new Map<string, Lineup>();
     }
 
     /**
@@ -14,7 +13,7 @@ export default class LineupsCache {
      */
     initialize(gameNames : Array<string>) : void {
         gameNames.forEach((name) => {
-            this.lineups.set(name, new Set());
+            this.lineups.set(name, new Lineup(name, []));
         });
     }
 
@@ -26,35 +25,35 @@ export default class LineupsCache {
     }
 
     /**
-     * Get a copy of a specified game's lineup
+     * Get the specified game's Lineup
      * @param name - name of the lineup to be retrieved
      */
-    getLineup(name : string) : Array<string> {
-        return Array(...this.lineups.get(name));
+    getLineup(name : string) : Lineup {
+        return this.lineups.get(name);
     }
 
     /**
-     * Get a deep copy of the list of lineups stored in the lineups cache.
+     * Get list of all the Lineup
      * @returns List of lineups per game
      */
-    getLineups() : Map<string, Array<string>> {
-        const lineupsCopy = new Map<string, Array<string>>();
-        this.lineups.forEach((lineup, gameName) => {
-            lineupsCopy.set(gameName, Array(...lineup));
+    getLineups() : Array<Lineup> {
+        const lineupsCopy = new Array<Lineup>();
+        this.lineups.forEach((lineup) => {
+            lineupsCopy.push(lineup);
         });
         return lineupsCopy;
     }
 
     /**
-     * Get a specific list of lineups
+     * Get a specific list of Lineups
      * @param gameNames - list of names of game lineups to fetch
      * @returns List of lineups per game
      */
-    getFilteredLineups(gameNames : Array<string>) : Map<string, Array<string>> {
-        const filteredLineups = new Map<string, Array<string>>();
+    getFilteredLineups(gameNames : Array<string>) : Array<Lineup> {
+        const filteredLineups = new Array<Lineup>();
         this.lineups.forEach((lineup, gameName) => {
             if (gameNames.includes(gameName)) {
-                filteredLineups.set(gameName, Array(...lineup));
+                filteredLineups.push(lineup);
             }
         })
         return filteredLineups;
@@ -64,11 +63,11 @@ export default class LineupsCache {
      * Get the lineups a user is part in
      * @param user
      */
-     getUserLineups(user : string) : Map<string, Array<string>> {
-        const userLineups = new Map<string, Array<string>>();
-        this.lineups.forEach((lineup, gameName) => {
-            if (lineup.has(user)) {
-                userLineups.set(gameName, Array(...lineup));
+     getUserLineups(user : string) : Array<Lineup> {
+        const userLineups = new Array<Lineup>();
+        this.lineups.forEach((lineup) => {
+            if (lineup.hasUser(user)) {
+                userLineups.push(lineup);
             }
         })
         return userLineups;
@@ -88,8 +87,7 @@ export default class LineupsCache {
      * @param users - user ids to be added to the lineup
      */
     addUsers = (name : string, users : Array<string>) : void => {
-        const lineup = this.lineups.get(name);
-        users.forEach((user) => lineup.add(user));
+        this.lineups.get(name).addUsers(users);
     }
 
     /**
@@ -98,7 +96,7 @@ export default class LineupsCache {
      * @param user - user id to be added to the lineup
      */
     joinLineups = (names : Array<string>, user : string) : void => {
-        names.forEach((name) => this.lineups.get(name).add(user));
+        names.forEach((name) => this.lineups.get(name).addUser(user));
     }
 
     /**
@@ -107,8 +105,7 @@ export default class LineupsCache {
      * @param users - user ids to be removed from the lineup
      */
     removeUsers(name : string, users : Array<string>) : void {
-        const lineup = this.lineups.get(name);
-        users.forEach((user) => lineup.delete(user));
+        const lineup = this.lineups.get(name).deleteUsers(users);
     }
 
     /**
@@ -117,7 +114,7 @@ export default class LineupsCache {
      * @param user - user id to be removed from the lineups
      */
     leaveLineups = (names : Array<string>, user : string) : void => {
-        names.forEach((name) => this.lineups.get(name).delete(user));
+        names.forEach((name) => this.lineups.get(name).deleteUser(user));
     }
 
     /**

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -72,9 +72,7 @@ export default class LineupsCache {
 
         if (gameLineup.length < limit) {
             gameLineup.push(user);
-            sendMessage(message.channel, 'User added.');
-        } else {
-            sendMessage(message.channel, `Lineup for \`${name}\` full.`);
+            sendMessage(message.channel, `User added to \`${name}\` lineup.`);
         }
     }
 

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -35,14 +35,6 @@ export default class LineupsCache {
     }
 
     /**
-     * Removes a lineup from the map ie. when a game is deleted.
-     * @param name - name of the lineup to be deleted
-     */
-    removeLineup(name : string) : void {
-        this.lineups.delete(name);
-    }
-
-    /**
      * Get a deep copy of the list of lineups stored in the lineups cache.
      * @returns List of lineups per game
      */
@@ -52,6 +44,29 @@ export default class LineupsCache {
             lineupsCopy.set(gameName, Array(...lineup));
         });
         return lineupsCopy;
+    }
+
+    /**
+     * Get a specific list of lineups
+     * @param names - list of names of game lineups to fetch
+     * @returns List of lineups per game
+     */
+    getFilteredLineups(names : Array<string>) : Map<string, Array<string>> {
+        const filteredLineups = new Map<string, Array<string>>();
+        this.lineups.forEach((lineup, gameName) => {
+            if (names.includes(gameName)) {
+                filteredLineups.set(gameName, Array(...lineup));
+            }
+        })
+        return filteredLineups;
+    }
+
+    /**
+     * Removes a lineup from the map ie. when a game is deleted.
+     * @param name - name of the lineup to be deleted
+     */
+    removeLineup(name : string) : void {
+        this.lineups.delete(name);
     }
 
     /**

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -64,11 +64,11 @@ export default class LineupsCache {
      * Get the lineups a user is part in
      * @param user
      */
-     getUserLineups(user : string) : Array<string> {
-        const userLineups = [];
-        this.lineups.forEach((gameLineup, gameName) => {
-            if (gameLineup.has(user)) {
-                userLineups.push(gameName);
+     getUserLineups(user : string) : Map<string, Array<string>> {
+        const userLineups = new Map<string, Array<string>>();
+        this.lineups.forEach((lineup, gameName) => {
+            if (lineup.has(user)) {
+                userLineups.set(gameName, Array(...lineup));
             }
         })
         return userLineups;

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -1,4 +1,4 @@
-import { Document } from 'mongoose';
+import { Document, UpdateWriteOpResult } from 'mongoose';
 import { ILineup, Lineup, Lineups } from '../models';
 
 export default class LineupsCache {
@@ -174,15 +174,23 @@ export default class LineupsCache {
     /**
      * Reset all lineups
      */
-    resetAllLineups() : void {
+    resetAllLineups() : Promise<UpdateWriteOpResult> {
         this.lineups.forEach((lineup) => lineup.clear());
+        return Lineups.updateMany(
+            {},
+            { users: [] },
+        ).exec();
     }
 
     /**
      * Reset specified lineups
      * @param gameNames - list of names of game lineups to be reset
      */
-    resetLineups(gameNames : Array<string>) : void {
+    resetLineups(gameNames : Array<string>) : Promise<UpdateWriteOpResult> {
         gameNames.forEach((gameName) => this.lineups.get(gameName).clear());
+        return Lineups.updateMany(
+            { gameName: { $in: gameNames } },
+            { users: [] },
+        ).exec();
     }
 };

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -73,7 +73,7 @@ export default class LineupsCache {
      * @param name - game name of the specified lineup
      * @param users - user ids to be added to the lineup
      */
-    addUsersToLineup = (name : string, users : Array<string>) : void => {
+    addUsers = (name : string, users : Array<string>) : void => {
         const lineup = this.lineups.get(name);
         users.forEach((user) => lineup.add(user));
     }
@@ -88,21 +88,13 @@ export default class LineupsCache {
     }
 
     /**
-     * Removes a user from a specified lineup
-     * @param bot - for sending error messages
-     * @param message - for replying to the original message
-     * @param name - name of the game of the relevant lineup
-     * @param user - user id to be added to the lineup
+     * Removes user/s from a specified lineup
+     * @param name - game name of the specified lineup
+     * @param users - user ids to be removed from the lineup
      */
-     removeUser(
-        bot : Client,
-        message : Message,
-        name : string,
-        user : string,
-    ) : void {
+    removeUsers(name : string, users : Array<string>) : void {
         const lineup = this.lineups.get(name);
-        lineup.delete(user);
-        sendMessage(message.channel, `User removed from \`${name}\` lineup.`);
+        users.forEach((user) => lineup.delete(user));;
     }
 
     /**

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -112,7 +112,9 @@ export default class LineupsCache {
      * @param gameName - game name of the specified lineup
      * @param users - user ids to be added to the lineup
      */
-    addUsers = (gameName : string, users : Array<string>) : Promise<ILineup & Document<any, any, ILineup>> => {
+    addUsers = (
+        gameName : string, users : Array<string>,
+    ) : Promise<ILineup & Document<any, any, ILineup>> => {
         this.lineups.get(gameName).addUsers(users);
         return Lineups.findOneAndUpdate(
             { gameName },
@@ -142,8 +144,14 @@ export default class LineupsCache {
      * @param gameName - game name of the specified lineup
      * @param users - user ids to be removed from the lineup
      */
-    removeUsers(gameName : string, users : Array<string>) : void {
+    removeUsers(
+        gameName : string, users : Array<string>,
+    ) : Promise<ILineup & Document<any, any, ILineup>> {
         const lineup = this.lineups.get(gameName).deleteUsers(users);
+        return Lineups.findOneAndUpdate(
+            { gameName },
+            { users: this.lineups.get(gameName).getUsers() }
+        ).exec();
     }
 
     /**

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -125,8 +125,16 @@ export default class LineupsCache {
      * @param gameNames - game names of the specified lineups
      * @param user - user id to be added to the lineup
      */
-    joinLineups = (gameNames : Array<string>, user : string) : void => {
+    joinLineups = (
+        gameNames : Array<string>, user : string,
+    ) : Promise<(ILineup & Document<any, any, ILineup>)[]> => {
         gameNames.forEach((gameName) => this.lineups.get(gameName).addUser(user));
+        return Promise.all(gameNames.map((gameName) => {
+            return Lineups.findOneAndUpdate(
+                { gameName },
+                { users: this.lineups.get(gameName).getUsers() },
+            ).exec()
+        }));
     }
 
     /**

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -21,8 +21,8 @@ export default class LineupsCache {
     /**
      * Fetch lineups data from the database to save in the local cache
      */
-    fetch() : void {
-        Lineups.find({}).exec().then((data) => {
+    fetch() : Promise<void> {
+        return Lineups.find({}).exec().then((data) => {
             const invalidLineups = [];
             data.forEach((lineup) => {
                 const gameName = lineup.gameName;
@@ -105,8 +105,12 @@ export default class LineupsCache {
      * @param gameName - game name of the specified lineup
      * @param users - user ids to be added to the lineup
      */
-    addUsers = (gameName : string, users : Array<string>) : void => {
+    addUsers = (gameName : string, users : Array<string>) : Promise<ILineup & Document<any, any, ILineup>> => {
         this.lineups.get(gameName).addUsers(users);
+        return Lineups.findOneAndUpdate(
+            { gameName },
+
+        ).exec();
     }
 
     /**

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -1,43 +1,87 @@
+import { Client, Message } from 'discord.js';
+import { Game } from '../models';
+import { sendMessage } from '../utils';
+
 export default class LineupsCache {
-    lineups: Map<string, Array<Array<string>>>;
+    lineups: Map<string, Array<string>>;
 
     constructor() {
-        this.lineups = new Map<string, Array<Array<string>>>();
+        this.lineups = new Map<string, Array<string>>();
     }
 
-    initialize = (gameNames : Array<string>) : void => {
+    /**
+     * initialize empty lineups for a list of games
+     * @param gameNames - list of games to make lineups for
+     */
+    initialize(gameNames : Array<string>) : void {
         gameNames.forEach((name) => {
             this.lineups.set(name, []);
         });
     }
 
-    fetch = () : void => {
+    /**
+     * Fetch lineups data from the database to save in the local cache
+     */
+    fetch() : void {
         // TODO: Fetch Lineups
+    }
+
+    /**
+     * Get a copy of a specified game's lineup
+     * @param name - name of the lineup to be retrieved
+     */
+    getLineup(name : string) : Array<string> {
+        return this.lineups.get(name).slice();
+    }
+
+    /**
+     * Removes a lineup from the map ie. when a game is deleted.
+     * @param name - name of the lineup to be deleted
+     */
+    removeLineup(name : string) : void {
+        this.lineups.delete(name);
     }
 
     /**
      * Get a deep copy of the list of lineups stored in the lineups cache.
      * @returns List of lineups per game
      */
-    getLineups() : Map<string, Array<Array<string>>> {
-        const lineupsCopy = new Map<string, Array<Array<string>>>();
-        this.lineups.forEach((gameLineups, gameName) => {
-            lineupsCopy.set(
-                gameName,
-                gameLineups.map((gameLineup) => gameLineup.slice()),
-            );
+    getLineups() : Map<string, Array<string>> {
+        const lineupsCopy = new Map<string, Array<string>>();
+        this.lineups.forEach((gameLineup, gameName) => {
+            lineupsCopy.set(gameName, gameLineup.slice());
         });
         return lineupsCopy;
     }
 
     /**
-     * Removes a lineup from the map ie. when a game is deleted.
+     * Adds a user to a specified lineup
+     * @param bot - for sending error messages
+     * @param message - for replying to the original message
+     * @param game - game data of the relevant lineup
+     * @param user - user id to be added to the lineup
      */
-    removeLineup = (name : string) : void => {
-        this.lineups.delete(name);
+    addUserToLineup(
+        bot : Client,
+        message : Message,
+        game : Game,
+        user : string,
+    ) : void {
+        const { name, limit } : { name : string, limit : number } = game;
+        const gameLineup = this.lineups.get(name);
+
+        if (gameLineup.length < limit) {
+            gameLineup.push(user);
+            sendMessage(message.channel, 'User added.');
+        } else {
+            sendMessage(message.channel, `Lineup for \`${name}\` full.`);
+        }
     }
 
-    resetAllLineups = () : void => {
+    /**
+     * Reset all lineups
+     */
+    resetAllLineups() : void {
         // TODO: Add role validation and/or a voting check
         Array(...this.lineups.keys()).forEach((gameName) => this.lineups.set(gameName, []));
     }

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -3,7 +3,7 @@ import { Game } from '../models';
 import { sendMessage } from '../utils';
 
 export default class LineupsCache {
-    lineups: Map<string, Set<string>>;
+    private lineups: Map<string, Set<string>>;
 
     constructor() {
         this.lineups = new Map<string, Set<string>>();

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -12,8 +12,8 @@ export default class LineupsCache {
      * @param gameNames - list of games to make lineups for
      */
     initialize(gameNames : Array<string>) : void {
-        gameNames.forEach((name) => {
-            this.lineups.set(name, new Lineup(name, []));
+        gameNames.forEach((gameName) => {
+            this.lineups.set(gameName, new Lineup(gameName, []));
         });
     }
 
@@ -43,10 +43,10 @@ export default class LineupsCache {
 
     /**
      * Get the specified game's Lineup
-     * @param name - name of the lineup to be retrieved
+     * @param gameName - game name of the lineup to be retrieved
      */
-    getLineup(name : string) : Lineup {
-        return this.lineups.get(name);
+    getLineup(gameName : string) : Lineup {
+        return this.lineups.get(gameName);
     }
 
     /**
@@ -63,7 +63,7 @@ export default class LineupsCache {
 
     /**
      * Get a specific list of Lineups
-     * @param gameNames - list of names of game lineups to fetch
+     * @param gameNames - game names of the specified lineups
      * @returns List of lineups per game
      */
     getFilteredLineups(gameNames : Array<string>) : Array<Lineup> {
@@ -92,37 +92,37 @@ export default class LineupsCache {
 
     /**
      * Removes a lineup from the map ie. when a game is deleted.
-     * @param name - name of the lineup to be deleted
+     * @param gameName - game name of the lineup to be deleted
      */
-    removeLineup(name : string) : void {
-        this.lineups.delete(name);
+    removeLineup(gameName : string) : void {
+        this.lineups.delete(gameName);
     }
 
     /**
      * Adds user/s to a specified lineup
-     * @param name - game name of the specified lineup
+     * @param gameName - game name of the specified lineup
      * @param users - user ids to be added to the lineup
      */
-    addUsers = (name : string, users : Array<string>) : void => {
-        this.lineups.get(name).addUsers(users);
+    addUsers = (gameName : string, users : Array<string>) : void => {
+        this.lineups.get(gameName).addUsers(users);
     }
 
     /**
      * Adds a user to specified lineups
-     * @param names - game names of the specified lineups
+     * @param gameNames - game names of the specified lineups
      * @param user - user id to be added to the lineup
      */
-    joinLineups = (names : Array<string>, user : string) : void => {
-        names.forEach((name) => this.lineups.get(name).addUser(user));
+    joinLineups = (gameNames : Array<string>, user : string) : void => {
+        gameNames.forEach((gameName) => this.lineups.get(gameName).addUser(user));
     }
 
     /**
      * Removes user/s from a specified lineup
-     * @param name - game name of the specified lineup
+     * @param gameName - game name of the specified lineup
      * @param users - user ids to be removed from the lineup
      */
-    removeUsers(name : string, users : Array<string>) : void {
-        const lineup = this.lineups.get(name).deleteUsers(users);
+    removeUsers(gameName : string, users : Array<string>) : void {
+        const lineup = this.lineups.get(gameName).deleteUsers(users);
     }
 
     /**
@@ -130,8 +130,8 @@ export default class LineupsCache {
      * @param gameNames - game names of the specified lineups
      * @param user - user id to be removed from the lineups
      */
-    leaveLineups = (names : Array<string>, user : string) : void => {
-        names.forEach((name) => this.lineups.get(name).deleteUser(user));
+    leaveLineups = (gameNames : Array<string>, user : string) : void => {
+        gameNames.forEach((gameName) => this.lineups.get(gameName).deleteUser(user));
     }
 
     /**
@@ -143,9 +143,9 @@ export default class LineupsCache {
 
     /**
      * Reset specified lineups
-     * @param names - list of names of game lineups to be reset
+     * @param gameNames - list of names of game lineups to be reset
      */
-    resetLineups(names : Array<string>) : void {
-        names.forEach((name) => this.lineups.get(name).clear());
+    resetLineups(gameNames : Array<string>) : void {
+        gameNames.forEach((gameName) => this.lineups.get(gameName).clear());
     }
 };

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -1,5 +1,4 @@
 import { Client, Message } from 'discord.js';
-import { Game } from '../models';
 import { sendMessage } from '../utils';
 
 export default class LineupsCache {
@@ -70,25 +69,22 @@ export default class LineupsCache {
     }
 
     /**
-     * Adds a user to a specified lineup
-     * @param bot - for sending error messages
-     * @param message - for replying to the original message
-     * @param game - game data of the relevant lineup
+     * Adds user/s to a specified lineup
+     * @param name - game name of the specified lineup
+     * @param users - user ids to be added to the lineup
+     */
+    addUsersToLineup = (name : string, users : Array<string>) : void => {
+        const lineup = this.lineups.get(name);
+        users.forEach((user) => lineup.add(user));
+    }
+
+    /**
+     * Adds a user to specified lineups
+     * @param names - game names of the specified lineups
      * @param user - user id to be added to the lineup
      */
-    addUser(
-        bot : Client,
-        message : Message,
-        game : Game,
-        user : string,
-    ) : void {
-        const { name, limit } : { name : string, limit : number } = game;
-        const lineup = this.lineups.get(name);
-
-        if (lineup.size < limit) {
-            lineup.add(user);
-            sendMessage(message.channel, `User added to \`${name}\` lineup.`);
-        }
+    joinLineups = (names : Array<string>, user : string) : void => {
+        names.forEach((name) => this.lineups.get(name).add(user));
     }
 
     /**

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -61,6 +61,20 @@ export default class LineupsCache {
     }
 
     /**
+     * Get the lineups a user is part in
+     * @param user
+     */
+     getUserLineups(user : string) : Array<string> {
+        const userLineups = [];
+        this.lineups.forEach((gameLineup, gameName) => {
+            if (gameLineup.has(user)) {
+                userLineups.push(gameName);
+            }
+        })
+        return userLineups;
+    }
+
+    /**
      * Removes a lineup from the map ie. when a game is deleted.
      * @param name - name of the lineup to be deleted
      */
@@ -94,7 +108,7 @@ export default class LineupsCache {
      */
     removeUsers(name : string, users : Array<string>) : void {
         const lineup = this.lineups.get(name);
-        users.forEach((user) => lineup.delete(user));;
+        users.forEach((user) => lineup.delete(user));
     }
 
     /**

--- a/src/caches/lineups.ts
+++ b/src/caches/lineups.ts
@@ -1,4 +1,5 @@
-import { Lineup, Lineups } from '../models';
+import { Document } from 'mongoose';
+import { ILineup, Lineup, Lineups } from '../models';
 
 export default class LineupsCache {
     private lineups: Map<string, Lineup>;
@@ -94,8 +95,9 @@ export default class LineupsCache {
      * Removes a lineup from the map ie. when a game is deleted.
      * @param gameName - game name of the lineup to be deleted
      */
-    removeLineup(gameName : string) : void {
+    removeLineup(gameName : string) : Promise<ILineup & Document<any, any, ILineup>> {
         this.lineups.delete(gameName);
+        return Lineups.findOneAndDelete({ gameName }).exec();
     }
 
     /**

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -1,4 +1,5 @@
 import { Client, Message } from 'discord.js';
+import { Game } from '../models/game.js';
 import GamesCache from './games.js';
 import LineupsCache from './lineups.js';
 import UsersCache from './users.js';
@@ -17,7 +18,7 @@ export default class LocalCache {
     /**
      * Update local cache with data from the DB
      */
-    fetchAll = () => {
+    fetchAll() : void {
         this.gamesCache.fetch().then(() => {
             this.initializeLineups();
             this.lineupsCache.fetch();
@@ -28,15 +29,23 @@ export default class LocalCache {
     /**
      * Initialize lineups
      */
-    initializeLineups = () => {
+    initializeLineups() : void {
         return this.lineupsCache.initialize(this.gamesCache.getGameNames());
     };
+
+    /**
+     * Get a copy of the data of a game
+     * @param name - name of the game
+     */
+    getGame(name : string) : Game {
+        return this.gamesCache.getGame(name);
+    }
 
     /**
      * Get a deep copy of the list of game names stored in the games cache.
      * @returns An array of strings with the list of the names of the games
      */
-    getGameNames = () : Array<string> => {
+    getGameNames() : Array<string> {
         return this.gamesCache.getGameNames();
     }
 
@@ -49,7 +58,7 @@ export default class LocalCache {
      * @param roleId - role to link to game
      * @param limit - number of slots for the game's lineup
      */
-     addGame(
+    addGame(
         bot : Client,
         message : Message,
         name : string,
@@ -68,7 +77,7 @@ export default class LocalCache {
      * @param roleId - role to link to game
      * @param limit - (optional) number of slots for the game's lineup
      */
-     editGame(
+    editGame(
         bot : Client,
         message : Message,
         name : string,
@@ -85,7 +94,7 @@ export default class LocalCache {
      * @param message - for replying to the original message
      * @param name - name of the game
      */
-     removeGame(
+    removeGame(
         bot : Client,
         message : Message,
         name : string,
@@ -95,10 +104,36 @@ export default class LocalCache {
     }
 
     /**
+     * Get a copy of a specified game's lineup
+     * @param name - name of the lineup to be retrieved
+     * @returns array of user id strings in the lineup
+     */
+    getLineup(name : string) : Array<string> {
+        return this.lineupsCache.getLineup(name);
+    }
+
+    /**
      * Get a deep copy of the list of lineups stored in the lineups cache.
      * @returns List of lineups per game
      */
-    getLineups() : Map<string, Array<Array<string>>> {
+    getLineups() : Map<string, Array<string>> {
         return this.lineupsCache.getLineups();
+    }
+
+    /**
+     * Adds a user to a specified lineup
+     * @param bot - for sending error messages
+     * @param message - for replying to the original message
+     * @param gameName - name of the game of the relevant lineup
+     * @param user - user id to be added to the lineup
+     */
+     addUserToLineup = (
+        bot : Client,
+        message : Message,
+        gameName : string,
+        user : string,
+    ) : void => {
+        const game : Game = this.gamesCache.getGame(gameName);
+        this.lineupsCache.addUserToLineup(bot, message, game, user);
     }
 };

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -16,10 +16,18 @@ export default class LocalCache {
     /**
      * Update local cache with data from the DB
      */
-    fetch = () => {
-        this.gamesCache.fetch();
-        this.lineupsCache.fetch();
-        this.usersCache.fetch();
+    fetchAll = () => {
+        this.gamesCache.fetch().then(() => {
+            this.initializeLineups();
+            this.lineupsCache.fetch();
+            this.usersCache.fetch();
+        });
+    };
+
+    /**
+     * Initialize lineups
+     */
+    initializeLineups = () => {
+        return this.lineupsCache.initialize(this.gamesCache.getGameNames());
     };
 };
-

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -1,5 +1,6 @@
 import { Client, Message } from 'discord.js';
 import { Game } from '../models/game.js';
+import { Lineup } from '../models/lineup.js';
 import GamesCache from './games.js';
 import LineupsCache from './lineups.js';
 import UsersCache from './users.js';
@@ -116,7 +117,7 @@ export default class LocalCache {
      * @param gameName - name of the lineup to be retrieved
      * @returns array of user id strings in the lineup
      */
-    getLineup(gameName : string) : Array<string> {
+    getLineup(gameName : string) : Lineup {
         return this.lineupsCache.getLineup(gameName);
     }
 
@@ -124,7 +125,7 @@ export default class LocalCache {
      * Get a deep copy of the list of lineups
      * @returns List of lineups per game
      */
-    getLineups() : Map<string, Array<string>> {
+    getLineups() : Array<Lineup> {
         return this.lineupsCache.getLineups();
     }
 
@@ -136,14 +137,10 @@ export default class LocalCache {
      */
     getFilteredLineups(
         gameNames : Array<string>, fullOnly : boolean = false,
-    ) : Map<string, Array<string>> {
+    ) : Array<Lineup> {
         const lineups = this.lineupsCache.getFilteredLineups(gameNames);
         if (fullOnly) {
-            lineups.forEach((_, gameName) => {
-                if (!this.isLineupFull(gameName)) {
-                    lineups.delete(gameName);
-                }
-            });
+            return lineups.filter((lineup) => this.isLineupFull(lineup.getGameName()));
         }
         return lineups;
     }
@@ -152,7 +149,7 @@ export default class LocalCache {
      * Get the lineups a user is part in
      * @param user
      */
-    getUserLineups(user : string) : Map<string, Array<string>> { 
+    getUserLineups(user : string) : Array<Lineup> { 
         return this.lineupsCache.getUserLineups(user);
     }
 
@@ -218,8 +215,8 @@ export default class LocalCache {
             return false;
         }
 
-        const lineup = this.getLineup(gameName);
-        if (lineup.length < limit) {
+        const userCount = this.getLineup(gameName).getUserCount();
+        if (userCount < limit) {
             return false;
         }
         return true;
@@ -235,7 +232,11 @@ export default class LocalCache {
             return Infinity;
         }
 
-        const lineup = this.getLineup(gameName);
-        return limit - lineup.length;
+        const userCount = this.getLineup(gameName).getUserCount();
+        return limit - userCount;
+    }
+
+    lineupHasUser(gameName, user) : boolean {
+        return this.getLineup(gameName).hasUser(user);
     }
 };

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -113,11 +113,20 @@ export default class LocalCache {
     }
 
     /**
-     * Get a deep copy of the list of lineups stored in the lineups cache.
+     * Get a deep copy of the list of lineups
      * @returns List of lineups per game
      */
     getLineups() : Map<string, Array<string>> {
         return this.lineupsCache.getLineups();
+    }
+
+    /**
+     * Get a specific list of lineups
+     * @param names - list of names of game lineups to fetch
+     * @returns List of lineups per game
+     */
+    getFilteredLineups(names : Array<string>) : Map<string, Array<string>> {
+        return this.lineupsCache.getFilteredLineups(names);
     }
 
     /**

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -1,6 +1,7 @@
 import { Client, Message } from 'discord.js';
+import { Document } from 'mongoose';
 import { Game } from '../models/game.js';
-import { Lineup } from '../models/lineup.js';
+import { ILineup, Lineup } from '../models/lineup.js';
 import GamesCache from './games.js';
 import LineupsCache from './lineups.js';
 import UsersCache from './users.js';
@@ -98,18 +99,13 @@ export default class LocalCache {
 
     /**
      * Function to handle `.game remove <name>`
-     * Remove a game from the cache and database
-     * @param bot - for sending error messages
-     * @param message - for replying to the original message
+     * Remove a game (and it's lineup/s) from the cache and database
      * @param name - name of the game
      */
-    removeGame(
-        bot : Client,
-        message : Message,
-        name : string,
-    ) : void {
-        this.gamesCache.removeGame(bot, message, name);
-        this.lineupsCache.removeLineup(name);
+    removeGame(name : string) : Promise<ILineup & Document<any, any, ILineup>> {
+        return this.gamesCache.removeGame(name).then(() => {
+            return this.lineupsCache.removeLineup(name);
+        });
     }
 
     /**

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -152,7 +152,7 @@ export default class LocalCache {
      * Get the lineups a user is part in
      * @param user
      */
-    getUserLineups(user : string) : Array<string> { 
+    getUserLineups(user : string) : Map<string, Array<string>> { 
         return this.lineupsCache.getUserLineups(user);
     }
 

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -134,6 +134,22 @@ export default class LocalCache {
         user : string,
     ) : void => {
         const game : Game = this.gamesCache.getGame(gameName);
-        this.lineupsCache.addUserToLineup(bot, message, game, user);
+        this.lineupsCache.addUser(bot, message, game, user);
+    }
+
+    /**
+     * Removes a user from a specified lineup
+     * @param bot - for sending error messages
+     * @param message - for replying to the original message
+     * @param gameName - name of the game of the relevant lineup
+     * @param user - user id to be added to the lineup
+     */
+     removeUserFromLineup = (
+        bot : Client,
+        message : Message,
+        gameName : string,
+        user : string,
+    ) : void => {
+        this.lineupsCache.removeUser(bot, message, gameName, user);
     }
 };

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -26,6 +26,13 @@ export default class LocalCache {
     };
 
     /**
+     * Initialize lineups
+     */
+    initializeLineups = () => {
+        return this.lineupsCache.initialize(this.gamesCache.getGameNames());
+    };
+
+    /**
      * Get a deep copy of the list of game names stored in the games cache.
      * @returns An array of strings with the list of the names of the games
      */
@@ -84,6 +91,7 @@ export default class LocalCache {
         name : string,
     ) : void {
         this.gamesCache.removeGame(bot, message, name);
+        this.lineupsCache.removeLineup(name);
     }
 
     /**
@@ -93,11 +101,4 @@ export default class LocalCache {
     getLineups() : Map<string, Array<Array<string>>> {
         return this.lineupsCache.getLineups();
     }
-
-    /**
-     * Initialize lineups
-     */
-    initializeLineups = () => {
-        return this.lineupsCache.initialize(this.gamesCache.getGameNames());
-    };
 };

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -171,8 +171,10 @@ export default class LocalCache {
      * @param gameName - game name of the specified lineup
      * @param users - user ids to be removed from the lineup
      */
-    removeUsersFromLineup(gameName : string, users : Array<string>) : void {
-        this.lineupsCache.removeUsers(gameName, users);
+    removeUsersFromLineup(
+        gameName : string, users : Array<string>,
+    ) : Promise<ILineup & Document<any, any, ILineup>> {
+        return this.lineupsCache.removeUsers(gameName, users);
     }
 
     /**

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -42,6 +42,14 @@ export default class LocalCache {
     }
 
     /**
+     * Get the role associated to a game
+     * @param name - name of the game
+     */
+    getRole(name : string) : Game {
+        return this.gamesCache.getGame(name);
+    }
+
+    /**
      * Get a deep copy of the list of game names stored in the games cache.
      * @returns An array of strings with the list of the names of the games
      */
@@ -130,6 +138,14 @@ export default class LocalCache {
     }
 
     /**
+     * Get the lineups a user is part in
+     * @param user
+     */
+    getUserLineups(user : string) : Array<string> { 
+        return this.getUserLineups(user);
+    }
+
+    /**
      * Adds user/s to a specified lineup
      * @param gameName - name of the game of the relevant lineup
      * @param users - user ids to be added to the lineup
@@ -159,7 +175,7 @@ export default class LocalCache {
     /**
      * Reset all lineups
      */
-     resetAllLineups() : void {
+    resetAllLineups() : void {
         this.lineupsCache.resetAllLineups();
     }
 
@@ -167,7 +183,39 @@ export default class LocalCache {
      * Reset specified lineups
      * @param gameNames - list of names of game lineups to be reset
      */
-     resetLineups(gameNames : Array<string>) : void {
+    resetLineups(gameNames : Array<string>) : void {
         this.lineupsCache.resetLineups(gameNames);
+    }
+
+    /**
+     * Check if lineup is full
+     * @param gameName - name of game lineup to check
+     * @returns boolean whether lineup is full
+     */
+    isLineupFull(gameName : string) : boolean {
+        const { isInfinite, limit } = this.getGame(gameName);
+        if (isInfinite) {
+            return false;
+        }
+
+        const lineup = this.getLineup(gameName);
+        if (lineup.length < limit) {
+            return false;
+        }
+        return true;
+    };
+
+    /**
+     * Check how many slots are available in a lineup
+     * @param gameName - name of game lineup to check
+     */
+    getLineupOpenings(gameName : string) : number {
+        const { isInfinite, limit } = this.getGame(gameName);
+        if (isInfinite) {
+            return Infinity;
+        }
+
+        const lineup = this.getLineup(gameName);
+        return limit - lineup.length;
     }
 };

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -1,5 +1,5 @@
 import { Client, Message } from 'discord.js';
-import { Document } from 'mongoose';
+import { Document, UpdateWriteOpResult } from 'mongoose';
 import { Game } from '../models/game.js';
 import { ILineup, Lineup } from '../models/lineup.js';
 import GamesCache from './games.js';
@@ -191,16 +191,16 @@ export default class LocalCache {
     /**
      * Reset all lineups
      */
-    resetAllLineups() : void {
-        this.lineupsCache.resetAllLineups();
+    resetAllLineups() : Promise<UpdateWriteOpResult> {
+        return this.lineupsCache.resetAllLineups();
     }
 
     /**
      * Reset specified lineups
      * @param gameNames - list of names of game lineups to be reset
      */
-    resetLineups(gameNames : Array<string>) : void {
-        this.lineupsCache.resetLineups(gameNames);
+    resetLineups(gameNames : Array<string>) : Promise<UpdateWriteOpResult> {
+        return this.lineupsCache.resetLineups(gameNames);
     }
 
     /**

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -20,7 +20,10 @@ export default class LocalCache {
     /**
      * Update local cache with data from the DB
      */
-    fetchAll() : Promise<void | [void, void]> {
+    fetchAll() : Promise<void | [
+        { missingLineups: ILineup[]; invalidLineups: (ILineup & Document<any, any, ILineup>)[]; },
+        void,
+    ]> {
         return this.gamesCache.fetch().then(() => {
             this.lineupsCache.initialize(this.gamesCache.getGameNames());
             return Promise.all([this.lineupsCache.fetch(), this.usersCache.fetch()]);
@@ -146,8 +149,10 @@ export default class LocalCache {
      * @param gameName - name of the game of the relevant lineup
      * @param users - user ids to be added to the lineup
      */
-    addUsersToLineup = (gameName : string, users : Array<string>) : void => {
-        this.lineupsCache.addUsers(gameName, users);
+    addUsersToLineup = (
+        gameName : string, users : Array<string>,
+    ) : Promise<ILineup & Document<any, any, ILineup>> => {
+        return this.lineupsCache.addUsers(gameName, users);
     }
 
     /**

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -130,20 +130,21 @@ export default class LocalCache {
     }
 
     /**
-     * Adds a user to a specified lineup
-     * @param bot - for sending error messages
-     * @param message - for replying to the original message
+     * Adds user/s to a specified lineup
      * @param gameName - name of the game of the relevant lineup
+     * @param users - user ids to be added to the lineup
+     */
+    addUsersToLineup = (gameName : string, users : Array<string>) : void => {
+        this.lineupsCache.addUsersToLineup(gameName, users);
+    }
+
+    /**
+     * Adds a user to specified lineups
+     * @param names - game names of the specified lineups
      * @param user - user id to be added to the lineup
      */
-     addUserToLineup = (
-        bot : Client,
-        message : Message,
-        gameName : string,
-        user : string,
-    ) : void => {
-        const game : Game = this.gamesCache.getGame(gameName);
-        this.lineupsCache.addUser(bot, message, game, user);
+    joinLineups = (names : Array<string>, user : string) : void => {
+        this.lineupsCache.joinLineups(names, user);
     }
 
     /**

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -182,8 +182,10 @@ export default class LocalCache {
      * @param gameNames - game names of the specified lineups
      * @param user - user id to be removed from the lineups
      */
-    leaveLineups = (gameNames : Array<string>, user : string) : void => {
-        this.lineupsCache.leaveLineups(gameNames, user);
+    leaveLineups = (
+        gameNames : Array<string>, user : string,
+    ) : Promise<(ILineup & Document<any, any, ILineup>)[]> => {
+        return this.lineupsCache.leaveLineups(gameNames, user);
     }
 
     /**

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -166,9 +166,9 @@ export default class LocalCache {
     }
 
     /**
-     * Adds a user to specified lineups
+     * Adds a user to the specified lineups
      * @param gameNames - game names of the specified lineups
-     * @param user - user id to be added to the lineup
+     * @param user - user id to be added to the lineups
      */
     joinLineups = (gameNames : Array<string>, user : string) : void => {
         this.lineupsCache.joinLineups(gameNames, user);
@@ -181,6 +181,15 @@ export default class LocalCache {
      */
     removeUsersFromLineup(gameName : string, users : Array<string>) : void {
         this.lineupsCache.removeUsers(gameName, users);
+    }
+
+    /**
+     * Removes a user from the specified lineups
+     * @param gameNames - game names of the specified lineups
+     * @param user - user id to be removed from the lineups
+     */
+    leaveLineups = (gameNames : Array<string>, user : string) : void => {
+        this.lineupsCache.leaveLineups(gameNames, user);
     }
 
     /**

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -45,8 +45,8 @@ export default class LocalCache {
      * Get the role associated to a game
      * @param name - name of the game
      */
-    getRole(name : string) : Game {
-        return this.gamesCache.getGame(name);
+    getRole(name : string) : string {
+        return this.gamesCache.getGame(name).roleId;
     }
 
     /**

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -152,4 +152,19 @@ export default class LocalCache {
     ) : void => {
         this.lineupsCache.removeUser(bot, message, gameName, user);
     }
+
+    /**
+     * Reset all lineups
+     */
+     resetAllLineups() : void {
+        this.lineupsCache.resetAllLineups();
+    }
+
+    /**
+     * Reset specified lineups
+     * @param names - list of names of game lineups to be reset
+     */
+     resetLineups(names : Array<string>) : void {
+        this.lineupsCache.resetLineups(names);
+    }
 };

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -105,11 +105,11 @@ export default class LocalCache {
 
     /**
      * Get a copy of a specified game's lineup
-     * @param name - name of the lineup to be retrieved
+     * @param gameName - name of the lineup to be retrieved
      * @returns array of user id strings in the lineup
      */
-    getLineup(name : string) : Array<string> {
-        return this.lineupsCache.getLineup(name);
+    getLineup(gameName : string) : Array<string> {
+        return this.lineupsCache.getLineup(gameName);
     }
 
     /**
@@ -122,11 +122,11 @@ export default class LocalCache {
 
     /**
      * Get a specific list of lineups
-     * @param names - list of names of game lineups to fetch
+     * @param gameNames - list of names of game lineups to fetch
      * @returns List of lineups per game
      */
-    getFilteredLineups(names : Array<string>) : Map<string, Array<string>> {
-        return this.lineupsCache.getFilteredLineups(names);
+    getFilteredLineups(gameNames : Array<string>) : Map<string, Array<string>> {
+        return this.lineupsCache.getFilteredLineups(gameNames);
     }
 
     /**
@@ -135,32 +135,25 @@ export default class LocalCache {
      * @param users - user ids to be added to the lineup
      */
     addUsersToLineup = (gameName : string, users : Array<string>) : void => {
-        this.lineupsCache.addUsersToLineup(gameName, users);
+        this.lineupsCache.addUsers(gameName, users);
     }
 
     /**
      * Adds a user to specified lineups
-     * @param names - game names of the specified lineups
+     * @param gameNames - game names of the specified lineups
      * @param user - user id to be added to the lineup
      */
-    joinLineups = (names : Array<string>, user : string) : void => {
-        this.lineupsCache.joinLineups(names, user);
+    joinLineups = (gameNames : Array<string>, user : string) : void => {
+        this.lineupsCache.joinLineups(gameNames, user);
     }
 
     /**
-     * Removes a user from a specified lineup
-     * @param bot - for sending error messages
-     * @param message - for replying to the original message
-     * @param gameName - name of the game of the relevant lineup
-     * @param user - user id to be added to the lineup
+     * Removes user/s from a specified lineup
+     * @param gameName - game name of the specified lineup
+     * @param users - user ids to be removed from the lineup
      */
-     removeUserFromLineup = (
-        bot : Client,
-        message : Message,
-        gameName : string,
-        user : string,
-    ) : void => {
-        this.lineupsCache.removeUser(bot, message, gameName, user);
+    removeUsersFromLineup(gameName : string, users : Array<string>) : void {
+        this.lineupsCache.removeUsers(gameName, users);
     }
 
     /**
@@ -172,9 +165,9 @@ export default class LocalCache {
 
     /**
      * Reset specified lineups
-     * @param names - list of names of game lineups to be reset
+     * @param gameNames - list of names of game lineups to be reset
      */
-     resetLineups(names : Array<string>) : void {
-        this.lineupsCache.resetLineups(names);
+     resetLineups(gameNames : Array<string>) : void {
+        this.lineupsCache.resetLineups(gameNames);
     }
 };

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -131,10 +131,21 @@ export default class LocalCache {
     /**
      * Get a specific list of lineups
      * @param gameNames - list of names of game lineups to fetch
+     * @param fullOnly - optional param to only fetch full lineups
      * @returns List of lineups per game
      */
-    getFilteredLineups(gameNames : Array<string>) : Map<string, Array<string>> {
-        return this.lineupsCache.getFilteredLineups(gameNames);
+    getFilteredLineups(
+        gameNames : Array<string>, fullOnly : boolean = false,
+    ) : Map<string, Array<string>> {
+        const lineups = this.lineupsCache.getFilteredLineups(gameNames);
+        if (fullOnly) {
+            lineups.forEach((_, gameName) => {
+                if (!this.isLineupFull(gameName)) {
+                    lineups.delete(gameName);
+                }
+            });
+        }
+        return lineups;
     }
 
     /**

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -149,9 +149,9 @@ export default class LocalCache {
      * @param gameName - name of the game of the relevant lineup
      * @param users - user ids to be added to the lineup
      */
-    addUsersToLineup = (
+    addUsersToLineup(
         gameName : string, users : Array<string>,
-    ) : Promise<ILineup & Document<any, any, ILineup>> => {
+    ) : Promise<ILineup & Document<any, any, ILineup>> {
         return this.lineupsCache.addUsers(gameName, users);
     }
 
@@ -160,9 +160,9 @@ export default class LocalCache {
      * @param gameNames - game names of the specified lineups
      * @param user - user id to be added to the lineups
      */
-    joinLineups = (
+    joinLineups(
         gameNames : Array<string>, user : string,
-    ) : Promise<(ILineup & Document<any, any, ILineup>)[]> => {
+    ) : Promise<(ILineup & Document<any, any, ILineup>)[]> {
         return this.lineupsCache.joinLineups(gameNames, user);
     }
 
@@ -182,9 +182,9 @@ export default class LocalCache {
      * @param gameNames - game names of the specified lineups
      * @param user - user id to be removed from the lineups
      */
-    leaveLineups = (
+    leaveLineups(
         gameNames : Array<string>, user : string,
-    ) : Promise<(ILineup & Document<any, any, ILineup>)[]> => {
+    ) : Promise<(ILineup & Document<any, any, ILineup>)[]> {
         return this.lineupsCache.leaveLineups(gameNames, user);
     }
 

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -160,8 +160,10 @@ export default class LocalCache {
      * @param gameNames - game names of the specified lineups
      * @param user - user id to be added to the lineups
      */
-    joinLineups = (gameNames : Array<string>, user : string) : void => {
-        this.lineupsCache.joinLineups(gameNames, user);
+    joinLineups = (
+        gameNames : Array<string>, user : string,
+    ) : Promise<(ILineup & Document<any, any, ILineup>)[]> => {
+        return this.lineupsCache.joinLineups(gameNames, user);
     }
 
     /**

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -1,11 +1,12 @@
+import { Client, Message } from 'discord.js';
 import GamesCache from './games.js';
 import LineupsCache from './lineups.js';
 import UsersCache from './users.js';
 
 export default class LocalCache {
-    gamesCache: GamesCache;
-    lineupsCache: LineupsCache;
-    usersCache: UsersCache;
+    private gamesCache: GamesCache;
+    private lineupsCache: LineupsCache;
+    private usersCache: UsersCache;
 
     constructor() {
         this.gamesCache = new GamesCache();
@@ -23,6 +24,75 @@ export default class LocalCache {
             this.usersCache.fetch();
         });
     };
+
+    /**
+     * Get a deep copy of the list of game names stored in the games cache.
+     * @returns An array of strings with the list of the names of the games
+     */
+    getGameNames = () : Array<string> => {
+        return this.gamesCache.getGameNames();
+    }
+
+    /**
+     * Function to handle `.game add <name> <role> <limit>`
+     * Add a game to local games cache and to the database
+     * @param bot - for sending error messages
+     * @param message - for replying to the original message
+     * @param name - name of the game
+     * @param roleId - role to link to game
+     * @param limit - number of slots for the game's lineup
+     */
+     addGame(
+        bot : Client,
+        message : Message,
+        name : string,
+        roleId : string,
+        limit : number,
+    ) : void {
+        this.gamesCache.addGame(bot, message, name, roleId, Number(limit));
+    }
+
+    /**
+     * Function to handle `.game edit <name> <role> <?limit>`
+     * Edit a game's set parameters
+     * @param bot - for sending error messages
+     * @param message - for replying to the original message
+     * @param name - name of the game
+     * @param roleId - role to link to game
+     * @param limit - (optional) number of slots for the game's lineup
+     */
+     editGame(
+        bot : Client,
+        message : Message,
+        name : string,
+        roleId : string,
+        limit ?: string,
+    ) : void {
+        this.gamesCache.editGame(bot, message, name, roleId, limit);
+    }
+
+    /**
+     * Function to handle `.game remove <name>`
+     * Remove a game from the cache and database
+     * @param bot - for sending error messages
+     * @param message - for replying to the original message
+     * @param name - name of the game
+     */
+     removeGame(
+        bot : Client,
+        message : Message,
+        name : string,
+    ) : void {
+        this.gamesCache.removeGame(bot, message, name);
+    }
+
+    /**
+     * Get a deep copy of the list of lineups stored in the lineups cache.
+     * @returns List of lineups per game
+     */
+    getLineups() : Map<string, Array<Array<string>>> {
+        return this.lineupsCache.getLineups();
+    }
 
     /**
      * Initialize lineups

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -20,19 +20,11 @@ export default class LocalCache {
     /**
      * Update local cache with data from the DB
      */
-    fetchAll() : void {
-        this.gamesCache.fetch().then(() => {
-            this.initializeLineups();
-            this.lineupsCache.fetch();
-            this.usersCache.fetch();
+    fetchAll() : Promise<void | [void, void]> {
+        return this.gamesCache.fetch().then(() => {
+            this.lineupsCache.initialize(this.gamesCache.getGameNames());
+            return Promise.all([this.lineupsCache.fetch(), this.usersCache.fetch()]);
         });
-    };
-
-    /**
-     * Initialize lineups
-     */
-    initializeLineups() : void {
-        return this.lineupsCache.initialize(this.gamesCache.getGameNames());
     };
 
     /**

--- a/src/caches/local.ts
+++ b/src/caches/local.ts
@@ -142,7 +142,7 @@ export default class LocalCache {
      * @param user
      */
     getUserLineups(user : string) : Array<string> { 
-        return this.getUserLineups(user);
+        return this.lineupsCache.getUserLineups(user);
     }
 
     /**

--- a/src/commands/game.ts
+++ b/src/commands/game.ts
@@ -27,12 +27,12 @@ function gameList(commandInputs : CommandInputs) {
 
     // arguments validated
     const gameNames = cache.getGameNames();
-    const title = 'Current available games';
+    const fieldTitle = 'Current available games';
     const content = gameNames.length ? gameNames.join('\n') : 'No games available';
     sendMessageEmbed(
         message.channel,
         'Game List',
-        { [title] : content },
+        { [fieldTitle] : content },
         () => {},
     );
 }

--- a/src/commands/game.ts
+++ b/src/commands/game.ts
@@ -1,7 +1,7 @@
 import { Client, Message, MessageEmbed } from 'discord.js';
 import { LocalCache } from '../caches';
 import { ALPHANUMERIC, PREFIX, RESERVED_KEYWORDS } from '../common/constants';
-import { isValidLimit, isValidRole, sendMessage, sendMessageEmbed } from '../utils';
+import { isValidLimit, isValidId, sendMessage, sendMessageEmbed } from '../utils';
 import { CommandInputs } from './processCommand';
 
 /**
@@ -67,7 +67,7 @@ function gameAdd(commandInputs : CommandInputs) {
     } else if (gameNames.includes(gameName)) {
         errorMessages.push('Invalid new game name. Already exists.');
     }
-    if (!isValidRole(role)) {
+    if (!isValidId(role)) {
         errorMessages.push('Invalid role.');
     }
     if (!isValidLimit(limit)) {
@@ -121,7 +121,7 @@ function gameEdit(commandInputs : CommandInputs) {
     } else if (!gameNames.includes(gameName)) {
         errorMessages.push(`Invalid game name. Does not exist. Perhaps you meant to use \`${PREFIX}game add\`?`);
     }
-    if (!isValidRole(role)) {
+    if (!isValidId(role)) {
         errorMessages.push('Invalid role.');
     }
     if (limit && !isValidLimit(limit)) {

--- a/src/commands/game.ts
+++ b/src/commands/game.ts
@@ -240,7 +240,7 @@ const gameCommands = [{
         'edit a game\'s role and limit',
     ],
 }, {
-    aliases: ['game remove'],
+    aliases: ['game remove', 'game delete'],
     run: gameRemove,
     formats: ['game remove <game>'],
     descriptions: ['delete a game'],

--- a/src/commands/game.ts
+++ b/src/commands/game.ts
@@ -1,7 +1,7 @@
 import { Client, Message } from 'discord.js';
 import { LocalCache } from '../caches';
 import { ALPHANUMERIC, PREFIX, RESERVED_KEYWORDS } from '../common/constants';
-import { isValidLimit, isValidRole, sendMessageEmbed } from '../utils';
+import { isValidLimit, isValidRole, sendErrorMessage, sendMessage, sendMessageEmbed } from '../utils';
 import { CommandInputs } from './processCommand';
 
 /**
@@ -190,7 +190,13 @@ function gameRemove(commandInputs : CommandInputs) {
     }
 
     // arguments validated
-    cache.removeGame(bot, message, gameName);
+    cache.removeGame(gameName).then(() => {
+        this.gamesMap.delete(gameName);
+        this.gameNames.delete(gameName);
+        sendMessage(message.channel, `Game \`${gameName}\` deleted.`);
+    }).catch((error) => {
+        sendErrorMessage(bot, error)
+    });;
 }
 
 /**

--- a/src/commands/game.ts
+++ b/src/commands/game.ts
@@ -26,7 +26,7 @@ function gameList(commandInputs : CommandInputs) {
     }
 
     // arguments validated
-    const gameNames = cache.gamesCache.getGameNames();
+    const gameNames = cache.getGameNames();
     const gameListEmbed = new MessageEmbed()
         .setTitle('Game List')
         .addField('Current available games', gameNames.length ? gameNames.join('\n') : 'No games available');
@@ -57,7 +57,7 @@ function gameAdd(commandInputs : CommandInputs) {
     }
 
     const [gameName, role, limit] = args.map(arg => arg?.toLowerCase());
-    const gameNames = cache.gamesCache.getGameNames();
+    const gameNames = cache.getGameNames();
     const errorMessages = [];
 
     if (!ALPHANUMERIC.test(gameName)) {
@@ -84,7 +84,7 @@ function gameAdd(commandInputs : CommandInputs) {
     }
 
     // arguments validated
-    cache.gamesCache.addGame(bot, message, gameName, role, Number(limit));
+    cache.addGame(bot, message, gameName, role, Number(limit));
 }
 
 /**
@@ -111,7 +111,7 @@ function gameEdit(commandInputs : CommandInputs) {
     }
  
     const [gameName, role, limit] = args.map(arg => arg?.toLowerCase());
-    const gameNames = cache.gamesCache.getGameNames();
+    const gameNames = cache.getGameNames();
     const errorMessages = [];
 
     if (!ALPHANUMERIC.test(gameName)) {
@@ -138,7 +138,7 @@ function gameEdit(commandInputs : CommandInputs) {
     }
 
     // arguments validated
-    cache.gamesCache.editGame(bot, message, gameName, role, limit);
+    cache.editGame(bot, message, gameName, role, limit);
 }
 
 /**
@@ -165,7 +165,7 @@ function gameRemove(commandInputs : CommandInputs) {
     }
  
     const gameName = args[0].toLowerCase();
-    const gameNames = cache.gamesCache.getGameNames();
+    const gameNames = cache.getGameNames();
     let errorMessage = '';
 
     if (!ALPHANUMERIC.test(gameName)) {
@@ -186,7 +186,7 @@ function gameRemove(commandInputs : CommandInputs) {
     }
 
     // arguments validated
-    cache.gamesCache.removeGame(bot, message, gameName);
+    cache.removeGame(bot, message, gameName);
 }
 
 /**

--- a/src/commands/game.ts
+++ b/src/commands/game.ts
@@ -190,7 +190,7 @@ function gameRemove(commandInputs : CommandInputs) {
 }
 
 /**
- * Inform command as invalid
+ * Inform game command as invalid
  * @param parameters - contains the necessary parameters for the command
  */
 function invalidGameCommand(commandInputs : CommandInputs) {
@@ -201,7 +201,7 @@ function invalidGameCommand(commandInputs : CommandInputs) {
             message.channel,
             `Invalid \`${PREFIX}game\` command`,
             `
-                Command for game lacking.
+                Command for \`${PREFIX}game\` lacking.
                 Possible options include \`list\`, \`add\`, \`edit\`, and \`remove\`.
                 ie. \`.game list\`
             `,

--- a/src/commands/game.ts
+++ b/src/commands/game.ts
@@ -1,7 +1,7 @@
 import { Client, Message, MessageEmbed } from 'discord.js';
 import { LocalCache } from '../caches';
 import { ALPHANUMERIC, PREFIX, RESERVED_KEYWORDS } from '../common/constants';
-import { isValidLimit, isValidId, sendMessage, sendMessageEmbed } from '../utils';
+import { isValidLimit, isValidRole, sendMessage, sendMessageEmbed } from '../utils';
 import { CommandInputs } from './processCommand';
 
 /**
@@ -67,7 +67,7 @@ function gameAdd(commandInputs : CommandInputs) {
     } else if (gameNames.includes(gameName)) {
         errorMessages.push('Invalid new game name. Already exists.');
     }
-    if (!isValidId(role)) {
+    if (!isValidRole(role)) {
         errorMessages.push('Invalid role.');
     }
     if (!isValidLimit(limit)) {
@@ -121,7 +121,7 @@ function gameEdit(commandInputs : CommandInputs) {
     } else if (!gameNames.includes(gameName)) {
         errorMessages.push(`Invalid game name. Does not exist. Perhaps you meant to use \`${PREFIX}game add\`?`);
     }
-    if (!isValidId(role)) {
+    if (!isValidRole(role)) {
         errorMessages.push('Invalid role.');
     }
     if (limit && !isValidLimit(limit)) {

--- a/src/commands/game.ts
+++ b/src/commands/game.ts
@@ -1,7 +1,7 @@
-import { Client, Message, MessageEmbed } from 'discord.js';
+import { Client, Message } from 'discord.js';
 import { LocalCache } from '../caches';
 import { ALPHANUMERIC, PREFIX, RESERVED_KEYWORDS } from '../common/constants';
-import { isValidLimit, isValidRole, sendMessage, sendMessageEmbed } from '../utils';
+import { isValidLimit, isValidRole, sendMessageEmbed } from '../utils';
 import { CommandInputs } from './processCommand';
 
 /**
@@ -27,10 +27,14 @@ function gameList(commandInputs : CommandInputs) {
 
     // arguments validated
     const gameNames = cache.getGameNames();
-    const gameListEmbed = new MessageEmbed()
-        .setTitle('Game List')
-        .addField('Current available games', gameNames.length ? gameNames.join('\n') : 'No games available');
-    sendMessage(message.channel, gameListEmbed, () => {});
+    const title = 'Current available games';
+    const content = gameNames.length ? gameNames.join('\n') : 'No games available';
+    sendMessageEmbed(
+        message.channel,
+        'Game List',
+        { [title] : content },
+        () => {},
+    );
 }
 
 /**

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -38,7 +38,11 @@ function help(commandInputs : CommandInputs) {
 
     const helpEmbed = new MessageEmbed()
         .setTitle('GentleBot Help')
-        .addField('Queueing Commands', 'e.g. \`.help\`');
+        .addField('Queueing Commands', 'e.g. \`.help\`')
+        .addField('Aliases', `
+            Commands for lineups usually have aliases, where the word \`${PREFIX}lineup\` is not included.
+            ie. \`${PREFIX}lineup add\` = \`${PREFIX}add\`
+        `);
     Object.entries(helpDescriptions).forEach(([category, commands]) => {
         helpEmbed.addField(category, commands.join('\n\n'), true);
     });

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -2,6 +2,7 @@ import { Message, MessageEmbed } from 'discord.js';
 import { PREFIX } from '../common/constants';
 import { sendMessage } from '../utils';
 import gameCommands from './game';
+import lineupCommands from './lineup';
 import { CommandInputs } from './processCommand';
 
 const getDescriptions = (commands) => {
@@ -24,7 +25,7 @@ const getDescriptions = (commands) => {
 
 const helpDescriptions = {
     'Games': getDescriptions(gameCommands),
-    'Test': ['\`.help\`\nshow help commands'],
+    'Lineups': getDescriptions(lineupCommands),
 };
 
 /**

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -2,7 +2,7 @@ import { Message, MessageEmbed } from 'discord.js';
 import { PREFIX } from '../common/constants';
 import { sendMessage } from '../utils';
 import gameCommands from './game';
-import lineupCommands from './lineup';
+import lineupCommands, { specialJoinCommand } from './lineup';
 import { CommandInputs } from './processCommand';
 
 const getDescriptions = (commands) => {
@@ -25,7 +25,7 @@ const getDescriptions = (commands) => {
 
 const helpDescriptions = {
     'Games': getDescriptions(gameCommands),
-    'Lineups': getDescriptions(lineupCommands),
+    'Lineups': getDescriptions([...lineupCommands, specialJoinCommand]),
 };
 
 /**

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -421,7 +421,7 @@ function lineupInvite(commandInputs : CommandInputs) {
         });
     } else { // invite all games user is in
         const user = `<@${message.author.id}>`;
-        userLineups = cache.getUserLineups(user);
+        userLineups = [...cache.getUserLineups(user).keys()];
         if (userLineups.length === 0) {
             errorMessages.push('User not in any lineup.')
         }

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -327,13 +327,14 @@ function lineupKick(commandInputs : CommandInputs) {
     }
 
     if (validUsers.length) {
-        cache.removeUsersFromLineup(gameName, validUsers);
-        content['Successfully kicked the following users'] = validUsers.join(' ');
+        cache.removeUsersFromLineup(gameName, validUsers).then(() => {
+            content['Successfully kicked the following users'] = validUsers.join(' ');
+            sendMessageEmbed(message.channel, 'Lineups Add', content);
+        });
     } else {
         content['No users kicked'] = 'No valid users';
+        sendMessageEmbed(message.channel, 'Lineups Kick', content);
     }
-
-    sendMessageEmbed(message.channel, 'Lineups Kick', content);
 }
 
 /**

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -650,4 +650,10 @@ const lineupCommands = [{
     descriptions: ['see the list of all game lineups', 'see the list of specified game lineups'],
 }];
 
+export const specialJoinCommand = {
+    run: lineupJoin,
+    formats: ['<game>'],
+    descriptions: ['join the specified lineup'],
+};
+
 export default lineupCommands;

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -28,7 +28,7 @@ function lineupList(commandInputs : CommandInputs) {
             const capitalisedGameName = `${gameName[0].toLocaleUpperCase()}${gameName.slice(1)}`;
             const gameLineupsString = gameLineup.length ? `${gameLineup.join(' ')}` : '\`No players in lineup\`';
             content[capitalisedGameName] = gameLineupsString;
-        })
+        }) 
         sendMessageEmbed(message.channel, 'Lineups', content);
     } else if (gameNames.length > 0) { // list specified lineups
         // validation
@@ -296,32 +296,6 @@ function lineupKick(commandInputs : CommandInputs) {
 }
 
 /**
- * Inform lineup command as invalid
- * @param parameters - contains the necessary parameters for the command
- */
-function invalidLineupCommand(commandInputs : CommandInputs) {
-    const { args, message } : { args : Array<string>, message : Message } = commandInputs;
-
-    if (args.length === 0) {
-        sendMessageEmbed(
-            message.channel,
-            `Invalid \`${PREFIX}lineup\` command`,
-            `
-                Command for \`${PREFIX}lineup\` lacking.
-                Possible options include \`list\`, \`join\`, \`add\`, \`kick\`, \`reset\`, and \`<game name>\`.
-                ie. \`.lineup list\`
-            `,
-        );
-        return;
-  }
-  sendMessageEmbed(
-      message.channel,
-      `Invalid \`${PREFIX}lineup\` command`,
-      `Command for \`${PREFIX}lineup\` unrecognized.`,
-  );
-}
-
-/**
  * Commands for lineups
  */
 const lineupCommands = [{
@@ -349,9 +323,6 @@ const lineupCommands = [{
     run: lineupReset,
     formats: ['lineup reset', 'lineup reset <game1> <game2> ...'],
     descriptions: ['reset all lineups', 'reset the specified lineups'],
-}, {
-    aliases: ['lineup'],
-    run: invalidLineupCommand,
 }];
 
 export default lineupCommands;

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -329,7 +329,7 @@ function lineupKick(commandInputs : CommandInputs) {
     if (validUsers.length) {
         cache.removeUsersFromLineup(gameName, validUsers).then(() => {
             content['Successfully kicked the following users'] = validUsers.join(' ');
-            sendMessageEmbed(message.channel, 'Lineups Add', content);
+            sendMessageEmbed(message.channel, 'Lineups Kick', content);
         });
     } else {
         content['No users kicked'] = 'No valid users';
@@ -401,13 +401,14 @@ function lineupLeave(commandInputs : CommandInputs) {
     }
 
     if (validGameNames.length) {
-        cache.leaveLineups(validGameNames, user);
-        content['User succesfully removed from the following lineups'] = `\`${validGameNames.join(' ')}\``;
+        cache.leaveLineups(validGameNames, user).then(() => {
+            content['User succesfully removed from the following lineups'] = `\`${validGameNames.join(' ')}\``;
+            sendMessageEmbed(message.channel, 'Lineups Leave', content);
+        });
     } else {
         content['User not removed from any lineup'] = 'No valid lineup';
+        sendMessageEmbed(message.channel, 'Lineups Leave', content);
     }
-
-    sendMessageEmbed(message.channel, 'Lineups Leave', content);
 }
 
 /**

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -14,7 +14,7 @@ import { CommandInputs } from './processCommand';
 function completeLineupWorker(
     commandInputs : CommandInputs, gameNames : Array<string>, content : Object,
 ) {
-    const { cache } : { cache : LocalCache } = commandInputs;
+    const { cache, message } : { cache : LocalCache, message : Message } = commandInputs;
     const completedLineupsStrings = [];
 
     cache.getFilteredLineups(gameNames, true).forEach((completedLineup, completedGameName) => {
@@ -23,7 +23,7 @@ function completeLineupWorker(
         `);
     });
     if (completedLineupsStrings.length > 0) {
-        content['Completed lineups'] = completedLineupsStrings.join('\n');
+        sendMessage(message.channel, completedLineupsStrings.join('\n'));
     }
 }
 

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -75,7 +75,7 @@ function invalidLineupCommand(commandInputs : CommandInputs) {
  * Commands for lineups
  */
 const lineupCommands = [{
-  aliases: ['lineup list', 'lineups'],
+  aliases: ['lineup list', 'lineup all', 'lineups', 'lineups list', 'lineups all'],
   run: lineupList,
   formats: ['lineup list'],
   descriptions: ['see the list of all game lineups'],

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -46,6 +46,32 @@ import { CommandInputs } from './processCommand';
 }
 
 /**
+ * Inform lineup command as invalid
+ * @param parameters - contains the necessary parameters for the command
+ */
+function invalidLineupCommand(commandInputs : CommandInputs) {
+    const { args, message } : { args : Array<string>, message : Message } = commandInputs;
+
+    if (args.length === 0) {
+        sendMessageEmbed(
+            message.channel,
+            `Invalid \`${PREFIX}lineup\` command`,
+            `
+                Command for \`${PREFIX}lineup\` lacking.
+                Possible options include \`list\`, \`join\`, \`add\`, \`kick\`, \`reset\`, and \`<game name>\`.
+                ie. \`.lineup list\`
+            `,
+        );
+        return;
+  }
+  sendMessageEmbed(
+      message.channel,
+      `Invalid \`${PREFIX}lineup\` command`,
+      `Command for \`${PREFIX}lineup\` unrecognized.`,
+  );
+}
+
+/**
  * Commands for lineups
  */
 const lineupCommands = [{
@@ -55,7 +81,7 @@ const lineupCommands = [{
   descriptions: ['see the list of all game lineups'],
 }, {
   aliases: ['lineup'],
-  // run: invalidLineupCommand,
+  run: invalidLineupCommand,
 }];
 
 export default lineupCommands;

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -238,10 +238,8 @@ function lineupKick(commandInputs : CommandInputs) {
  * @param parameters - contains the necessary parameters for the command
  */
  function lineupReset(commandInputs : CommandInputs) {
-    const {
-        args, bot, cache, command, message,
-    } : {
-        args : Array<string>, bot : Client, cache : LocalCache, command : string, message : Message,
+    const { args, cache, message } : {
+        args : Array<string>, cache : LocalCache, message : Message,
     } = commandInputs;
 
     // validation

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -253,15 +253,17 @@ function lineupJoin(commandInputs : CommandInputs) {
     }
 
     if (validGameNames.length) {
-        cache.joinLineups(validGameNames, user);
-        content['Successfully added the user to the following lineups'] = `\`${validGameNames.join(' ')}\``;
+        cache.joinLineups(validGameNames, user).then(() => {
+            content['Successfully added the user to the following lineups'] = `\`${validGameNames.join(' ')}\``;
+            completeLineupWorker(commandInputs, validGameNames);
+            sendMessageEmbed(message.channel, 'Lineups Join', content);
+        });
 
-        completeLineupWorker(commandInputs, validGameNames);
     } else {
         content['User not added to any lineup'] = 'No valid lineup';
+        sendMessageEmbed(message.channel, 'Lineups Join', content);
     }
 
-    sendMessageEmbed(message.channel, 'Lineups Join', content);
 }
 
 /**

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -164,8 +164,7 @@ function lineupAdd(commandInputs : CommandInputs) {
     }
 
     if (validUsers.length) {
-        cache.addUsersToLineup(gameName, validUsers).then((output) => {
-            console.log('DEBUG: output', output);
+        cache.addUsersToLineup(gameName, validUsers).then(() => {
             content['Successfully added the following users'] = validUsers.join(' ');
             
             completeLineupWorker(commandInputs, [gameName]);

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -396,6 +396,8 @@ function lineupLeave(commandInputs : CommandInputs) {
     if (validGameNames.length) {
         cache.leaveLineups(validGameNames, user);
         content['User succesfully removed from the following lineups'] = `\`${validGameNames.join(' ')}\``;
+    } else {
+        content['User not removed from any lineup'] = 'No valid lineup';
     }
 
     sendMessageEmbed(message.channel, 'Lineups Leave', content);

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -31,7 +31,7 @@ function lineupList(commandInputs : CommandInputs) {
     const lineupsListEmbed = new MessageEmbed().setTitle('Lineups');
     lineups.forEach((gameLineup, gameName) => {
         const capitalisedGameName = `${gameName[0].toLocaleUpperCase()}${gameName.slice(1)}`;
-        const gameLineupsString = gameLineup.length ? `\`${gameLineup.join(', ')}\`` : '\`No players in lineup\`';
+        const gameLineupsString = gameLineup.length ? `${gameLineup.join(' ')}` : '\`No players in lineup\`';
         lineupsListEmbed.addField(capitalisedGameName, gameLineupsString);
     });
 

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -1,0 +1,61 @@
+
+import { Message, MessageEmbed } from "discord.js";
+import { LocalCache } from "../caches";
+import { PREFIX } from "../common/constants";
+import { sendMessage, sendMessageEmbed } from '../utils';
+import { CommandInputs } from './processCommand';
+
+/**
+ * Function for lineup list command
+ * Sends list of all lineups
+ * @param commandInputs - contains the necessary parameters for the command
+ */
+ function lineupList(commandInputs : CommandInputs) {
+  const { args, cache, command, message } : {
+      args : Array<string>, cache : LocalCache, command : string, message : Message,
+  } = commandInputs;
+
+  // validation
+  const argsCount = args.length;
+  if (argsCount !== 0) {
+      sendMessageEmbed(
+          message.channel,
+          'Unexpected number of arguments',
+          `Expected 0 arguments for \`${PREFIX}${command}\`. Received ${argsCount}.`,
+      );
+      return;
+  }
+
+  // arguments validated
+  const lineups = cache.lineupsCache.getLineups();
+  const lineupsListEmbed = new MessageEmbed()
+      .setTitle('Lineups');
+  lineups.forEach((gameLineups, gameName) => {
+    const capitalisedGameName = `${gameName[0].toLocaleUpperCase()}${gameName.slice(1)}`;
+    if (gameLineups.length === 0) {
+      lineupsListEmbed.addField(capitalisedGameName, 'No lineups');
+    } else {
+      const gameLineupsString = gameLineups.length ? gameLineups.map(
+        (gameLineup, index) => `\`${index}\` : \`${gameLineup.join(', ')}\``,
+      ).join('\n') : '\`No players in lineup\`';
+      lineupsListEmbed.addField(capitalisedGameName, gameLineupsString);
+    }
+  });
+
+  sendMessage(message.channel, lineupsListEmbed, () => {});
+}
+
+/**
+ * Commands for lineups
+ */
+const lineupCommands = [{
+  aliases: ['lineup list', 'lineups'],
+  run: lineupList,
+  formats: ['lineup list'],
+  descriptions: ['see the list of all game lineups'],
+}, {
+  aliases: ['lineup'],
+  // run: invalidLineupCommand,
+}];
+
+export default lineupCommands;

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -6,7 +6,7 @@ import { isValidUser, sendMessageEmbed } from '../utils';
 import { CommandInputs } from './processCommand';
 
 /**
- * Function for lineup list commands
+ * Function for `lineup list`  / `lineup list <game/s>` commands
  * Sends list of all lineups
  * @param commandInputs - contains the necessary parameters for the command
  */
@@ -65,9 +65,9 @@ function lineupList(commandInputs : CommandInputs) {
 }
 
 /**
- * Function to handle `.lineup add <game> <user id/s>`
+ * Function to handle `lineup add <game> <user id/s>`
  * Add the user to the game's lineup
- * @param parameters - contains the necessary parameters for the command
+ * @param commandInputs - contains the necessary parameters for the command
  */
 function lineupAdd(commandInputs : CommandInputs) {
     const {
@@ -150,9 +150,9 @@ function lineupAdd(commandInputs : CommandInputs) {
 }
 
 /**
- * Function to handle `.lineup join <game/s>`
+ * Function to handle `lineup join <game/s>`
  * Add the user that sent the message to the game's lineup
- * @param parameters - contains the necessary parameters for the command
+ * @param commandInputs - contains the necessary parameters for the command
  */
 function lineupJoin(commandInputs : CommandInputs) {
     const {
@@ -237,9 +237,9 @@ function lineupJoin(commandInputs : CommandInputs) {
 }
 
 /**
- * Function to handle `.lineup kick <game> <user id>`
+ * Function to handle `lineup kick <game> <user id>`
  * Remove the user from the game's lineup
- * @param parameters - contains the necessary parameters for the command
+ * @param commandInputs - contains the necessary parameters for the command
  */
 function lineupKick(commandInputs : CommandInputs) {
     const {
@@ -283,11 +283,11 @@ function lineupKick(commandInputs : CommandInputs) {
     }
 
     // non-blocking validation
-    const content = {};
     const lineup = cache.getLineup(gameName);
-    
     const invalidUsers = users.filter((user) => !lineup.includes(user)); // not in lineup
     const validUsers = users.filter((user) => lineup.includes(user)); // already in lineup
+
+    const content = {};
 
     if (invalidUsers.length) {
         content['Following users not in the lineup'] = invalidUsers.join(' ');
@@ -304,9 +304,9 @@ function lineupKick(commandInputs : CommandInputs) {
 }
 
 /**
- * Function to handle `lineup reset` commands
+ * Function to handle `lineup reset` / `lineup reset <game/s>` commands
  * Remove the user from the game's lineup
- * @param parameters - contains the necessary parameters for the command
+ * @param commandInputs - contains the necessary parameters for the command
  */
 function lineupReset(commandInputs : CommandInputs) {
     const { args, cache, message } : {
@@ -365,13 +365,15 @@ function lineupReset(commandInputs : CommandInputs) {
 }
 
 /**
- * 
+ * Function to handle `lineup invite` / `lineup invite <game/s>` commands
+ * Send invites for lineups depending on command args (or lack thereof)
+ * @param commandInputs - contains the necessary parameters for the command
  */
 function lineupInvite(commandInputs : CommandInputs) {
     const {
-        args, cache, command, message,
+        args, cache, message,
     } : {
-        args : Array<string>, cache : LocalCache, command : string, message : Message,
+        args : Array<string>, cache : LocalCache, message : Message,
     } = commandInputs;
 
     const gameNames = args.map(arg => arg?.trim()?.toLowerCase());

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -2,7 +2,7 @@
 import { Message } from "discord.js";
 import { LocalCache } from "../caches";
 import { ALPHANUMERIC, PREFIX, READY_MESSAGE } from "../common/constants";
-import { isValidUser, sendMessageEmbed } from '../utils';
+import { isValidUser, sendMessage, sendMessageEmbed } from '../utils';
 import { CommandInputs } from './processCommand';
 
 /**
@@ -521,23 +521,23 @@ function lineupInvite(commandInputs : CommandInputs) {
     });
 
     // info messages and actual cache operations
-    const content = {};
-
     if (fullGameNames.length) {
+        const content = {};
         content['Following lineups are already full'] = `\`${fullGameNames.join(' ')}\``;
+        sendMessageEmbed(message.channel, 'Lineup Invites Info', content);
     }
 
     if (validGameNames.length) {
-        content['Invite Lineups'] = `
+        const inviteMessage = `
             ${validGameNames.map((gameName) => {
                 const role = cache.getRole(gameName);
                 const slots = cache.getLineupOpenings(gameName);
                 return `${role} +${slots}`;
             }).join('\n')}
-        `;
+        `;  
+        sendMessage(message.channel, inviteMessage);
     }
 
-    sendMessageEmbed(message.channel, 'Lineups Invite', content);
 }
 
 /**

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -590,18 +590,16 @@ function lineupInvite(commandInputs : CommandInputs) {
     const uniqueGameNames = Array(...new Set(gameNames));
     const validGameNames = isSpecifiedReady ? uniqueGameNames : userLineups;
 
-    const content = {};
-
     if (validGameNames.length) {
+        const readyMessages = [];
         const validLineups = cache.getFilteredLineups(validGameNames);
         validLineups.forEach((lineup, gameName) => {
-            content[`${READY_MESSAGE} \`${gameName}\``] = lineup.join(' ');
+            readyMessages.push(`${READY_MESSAGE} \`${gameName}\` ${lineup.join(' ')}`);
         });
+        sendMessage(message.channel, readyMessages.join('\n'));
     } else {
-        content['No games ready'] = 'No valid lineup';
+        sendMessage(message.channel, 'No lineups ready');
     }
-
-    sendMessageEmbed(message.channel, 'Lineup Ready', content);
 }
 
 

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -595,7 +595,7 @@ function lineupInvite(commandInputs : CommandInputs) {
     if (validGameNames.length) {
         const validLineups = cache.getFilteredLineups(validGameNames);
         validLineups.forEach((lineup, gameName) => {
-            content[`${READY_MESSAGE} ${gameName.toLocaleUpperCase()}`] = lineup.join(' ');
+            content[`${READY_MESSAGE} \`${gameName}\``] = lineup.join(' ');
         });
     } else {
         content['No games ready'] = 'No valid lineup';

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -6,6 +6,28 @@ import { isValidUser, sendMessageEmbed } from '../utils';
 import { CommandInputs } from './processCommand';
 
 /**
+ * Worker function to check for complete lineups
+ * @param commandInputs - contains cache to fetch lineups
+ * @param gameNames - list of games to check
+ * @param content - 
+ */
+function completeLineupWorker(
+    commandInputs : CommandInputs, gameNames : Array<string>, content : Object,
+) {
+    const { cache } : { cache : LocalCache } = commandInputs;
+    const completedLineupsStrings = [];
+
+    cache.getFilteredLineups(gameNames, true).forEach((completedLineup, completedGameName) => {
+        completedLineupsStrings.push(`
+            ${completedGameName.toUpperCase()} Lineup Complete: ${completedLineup.join(' ')}
+        `);
+    });
+    if (completedLineupsStrings.length > 0) {
+        content['Completed lineups'] = completedLineupsStrings.join('\n');
+    }
+}
+
+/**
  * Function for `lineup list`  / `lineup list <game/s>` commands
  * Sends list of all lineups
  * @param commandInputs - contains the necessary parameters for the command
@@ -138,6 +160,8 @@ function lineupAdd(commandInputs : CommandInputs) {
     if (validUsers.length) {
         cache.addUsersToLineup(gameName, validUsers);
         content['Successfully added the following users'] = validUsers.join(' ');
+
+        completeLineupWorker(commandInputs, [gameName], content);
     } else {
         content['No users added'] = 'No valid users';
     }
@@ -229,6 +253,8 @@ function lineupJoin(commandInputs : CommandInputs) {
     if (validGameNames.length) {
         cache.joinLineups(validGameNames, user);
         content['Successfully added the user to the following lineups'] = `\`${validGameNames.join(' ')}\``;
+
+        completeLineupWorker(commandInputs, validGameNames, content);
     } else {
         content['User not added to any lineup'] = 'No valid lineup';
     }

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -19,7 +19,7 @@ function completeLineupWorker(
 
     cache.getFilteredLineups(gameNames, true).forEach((completedLineup, completedGameName) => {
         completedLineupsStrings.push(`
-            ${completedGameName.toLocaleUpperCase()} Lineup Complete: ${completedLineup.join(' ')}
+            \`${completedGameName.toLocaleUpperCase()}\` Lineup Complete: ${completedLineup.join(' ')}
         `);
     });
     if (completedLineupsStrings.length > 0) {
@@ -47,7 +47,7 @@ function lineupList(commandInputs : CommandInputs) {
         const lineups = cache.getLineups();
         const content = {};
         lineups.forEach((gameLineup, gameName) => {
-            const capitalisedGameName = `${gameName[0].toLocaleUpperCase()}${gameName.slice(1)}`;
+            const capitalisedGameName = `${gameName.toLocaleUpperCase()}`;
             const gameLineupsString = gameLineup.length ? `${gameLineup.join(' ')}` : '\`No players in lineup\`';
             content[capitalisedGameName] = gameLineupsString;
         }) 
@@ -78,7 +78,7 @@ function lineupList(commandInputs : CommandInputs) {
         const lineups = cache.getFilteredLineups(Array(...uniqueGameNames));
         const content = {};
         lineups.forEach((gameLineup, gameName) => {
-            const capitalisedGameName = `${gameName[0].toLocaleUpperCase()}${gameName.slice(1)}`;
+            const capitalisedGameName = `${gameName.toLocaleUpperCase()}`;
             const gameLineupsString = gameLineup.length ? `${gameLineup.join(' ')}` : '\`No players in lineup\`';
             content[capitalisedGameName] = gameLineupsString;
         })
@@ -532,7 +532,7 @@ function lineupInvite(commandInputs : CommandInputs) {
             ${validGameNames.map((gameName) => {
                 const role = cache.getRole(gameName);
                 const slots = cache.getLineupOpenings(gameName);
-                return `${role} +${slots}`;
+                return `\`${gameName.toLocaleUpperCase()}\` ${role} +${slots}`;
             }).join('\n')}
         `;  
         sendMessage(message.channel, inviteMessage);
@@ -594,7 +594,7 @@ function lineupInvite(commandInputs : CommandInputs) {
         const readyMessages = [];
         const validLineups = cache.getFilteredLineups(validGameNames);
         validLineups.forEach((lineup, gameName) => {
-            readyMessages.push(`${READY_MESSAGE} \`${gameName}\` ${lineup.join(' ')}`);
+            readyMessages.push(`${READY_MESSAGE} \`${gameName.toLocaleUpperCase()}\` ${lineup.join(' ')}`);
         });
         sendMessage(message.channel, readyMessages.join('\n'));
     } else {

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -447,22 +447,24 @@ function lineupReset(commandInputs : CommandInputs) {
     const uniqueGameNames = Array(...new Set(gameNames));
 
     if (uniqueGameNames.length === 0) {
-        cache.resetAllLineups();
-        sendMessageEmbed(
-            message.channel,
-            'Notification',
-            'All lineups have been reset.',
-        );
+        cache.resetAllLineups().then(() => {
+            sendMessageEmbed(
+                message.channel,
+                'Notification',
+                'All lineups have been reset.',
+            );
+        });
     } else if (uniqueGameNames.length > 0) {
-        cache.resetLineups(uniqueGameNames);
-        const fieldTitle = 'The following lineups have been reset';
-        sendMessageEmbed(
-            message.channel,
-            'Notification',
-            {
-                [fieldTitle]: uniqueGameNames.join('\n'),
-            },
-        );
+        cache.resetLineups(uniqueGameNames).then(() => {
+            const fieldTitle = 'The following lineups have been reset';
+            sendMessageEmbed(
+                message.channel,
+                'Notification',
+                {
+                    [fieldTitle]: uniqueGameNames.join('\n'),
+                },
+            );
+        });
     } else {
         sendMessageEmbed(
             message.channel,

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -159,20 +159,22 @@ function lineupAdd(commandInputs : CommandInputs) {
         content['Following users already in the lineup'] = invalidUsers.join(' ');
     }
 
-    if (validUsers.length) {
-        cache.addUsersToLineup(gameName, validUsers);
-        content['Successfully added the following users'] = validUsers.join(' ');
-
-        completeLineupWorker(commandInputs, [gameName]);
-    } else {
-        content['No users added'] = 'No valid users';
-    }
-
     if (excludedUsers.length) {
         content['Cannot add the following users'] = excludedUsers.join(' ');
     }
 
-    sendMessageEmbed(message.channel, 'Lineups Add', content);
+    if (validUsers.length) {
+        cache.addUsersToLineup(gameName, validUsers).then((output) => {
+            console.log('DEBUG: output', output);
+            content['Successfully added the following users'] = validUsers.join(' ');
+            
+            completeLineupWorker(commandInputs, [gameName]);
+            sendMessageEmbed(message.channel, 'Lineups Add', content);
+        });
+    } else {
+        content['No users added'] = 'No valid users';
+        sendMessageEmbed(message.channel, 'Lineups Add', content);
+    }
 }
 
 /**

--- a/src/commands/processCommand.ts
+++ b/src/commands/processCommand.ts
@@ -4,7 +4,7 @@ import { PREFIX } from '../common/constants';
 import { sendMessageEmbed } from '../utils';
 import gameCommands from './game';
 import helpCommands from './help';
-import lineupCommands from './lineup';
+import lineupCommands, { specialJoinCommand } from './lineup';
 
 /**
  * Class for generalizing inputs to command functions
@@ -48,33 +48,47 @@ const getCommandRegExp = (command : string) : RegExp => new RegExp(`^${PREFIX}($
  */
 export default function processCommand(bot : Client, cache: LocalCache, message : Message) : void {
     const { content = '' } : { content : string } = message;
-    
-    let command : string = '';
-    let args : Array<string> = [];
+    const cleanedContent = content.trim();
 
-    commands.every(({ aliases, run }) => {
+    let isValidCommand = commands.some(({ aliases, run }) => {
         for (const alias of aliases) {
-            const result = getCommandRegExp(alias).exec(content);
+            const result = getCommandRegExp(alias).exec(cleanedContent);
             if (result !== null) { // check if command is valid
-                command = result[1].trim();
-                if (result[2].trim().length > 0) {
-                    args = result[2].trim().split(' ').filter((arg) => arg.length);
-                }
+                const command = result[1].trim();
+                const args = result[2].trim().split(' ').filter((arg) => arg.length);
 
                 const parameters = new CommandInputs(args, bot, cache, command, message);
                 run(parameters);
-                break;
+                return true;
             }
         }
 
-        return command === '';
+        return false;
     });
 
-    if (args === null) {
+    if (!isValidCommand) { // test for special game name join command
+        const { run } = specialJoinCommand;
+        const aliases = cache.getGameNames();
+
+        isValidCommand = aliases.some((alias) => {
+            if (cleanedContent.localeCompare(`${PREFIX}${alias}`) === 0) { // check if command matches
+                const command = 'lineup join';
+                const args = [alias];
+
+                const parameters = new CommandInputs(args, bot, cache, command, message);
+                run(parameters);
+                return true;
+            }
+
+            return false;
+        })
+    }
+
+    if (!isValidCommand) { // no valid command
         sendMessageEmbed(
             message.channel,
             'Wrong command',
-            `No valid command detected in \`${content}\``,
+            `No valid command detected in \`${cleanedContent}\``,
         );
     }
 };

--- a/src/commands/processCommand.ts
+++ b/src/commands/processCommand.ts
@@ -1,5 +1,6 @@
 import { Client, Message } from 'discord.js';
 import { LocalCache } from '../caches';
+import { PREFIX } from '../common/constants';
 import { sendMessageEmbed } from '../utils';
 import gameCommands from './game';
 import helpCommands from './help';
@@ -37,7 +38,7 @@ const commands = [
 ];
 
 // No need to check for prefix in command
-const getCommandRegExp = (command : string) : RegExp => new RegExp(`(${command})\\b(.*)`, 'gi');
+const getCommandRegExp = (command : string) : RegExp => new RegExp(`^${PREFIX}(${command})\\b(.*)`, 'gi');
 
 /**
  * Process the command sent by the user (contained in msg param)

--- a/src/commands/processCommand.ts
+++ b/src/commands/processCommand.ts
@@ -3,6 +3,7 @@ import { LocalCache } from '../caches';
 import { sendMessageEmbed } from '../utils';
 import gameCommands from './game';
 import helpCommands from './help';
+import lineupCommands from './lineup';
 
 /**
  * Class for generalizing inputs to command functions
@@ -32,6 +33,7 @@ export class CommandInputs {
 const commands = [
     ...helpCommands,
     ...gameCommands,
+    ...lineupCommands,
 ];
 
 // No need to check for prefix in command

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -16,6 +16,7 @@ export const PUNISH_TIME_DEL = 500;
 
 export const RESERVED_KEYWORDS = [
     'add',
+    'all',
     'edit',
     'game',
     'games',

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -15,11 +15,14 @@ export const PUNISH_TAG = '<@&747740479638208532>';
 export const PUNISH_ID = '747740479638208532'
 export const PUNISH_TIME_DEL = 500;
 
+export const READY_MESSAGE = 'G ';
+
 export const RESERVED_KEYWORDS = [
     'add',
     'all',
     'delete',
     'edit',
+    'g',
     'game',
     'games',
     'gamelist',
@@ -30,6 +33,7 @@ export const RESERVED_KEYWORDS = [
     'lineup',
     'lineups',
     'list',
+    'ready',
     'remove',
     'reset',
     'save',

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -17,6 +17,7 @@ export const PUNISH_TIME_DEL = 500;
 export const RESERVED_KEYWORDS = [
     'add',
     'all',
+    'delete',
     'edit',
     'game',
     'games',

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -3,9 +3,10 @@ dotenv.config();
 
 export const PREFIX = '.'; // TODO: Replace with slash commands
 
-export const MSG_TIME_DEL = 3000;
-export const MSG_TIME_FULL_DEL = 10000;
-export const INFO_MSG_TIME_DEL = 60000;
+export const NOTIF_MSG_TIME_DEL = 5000;
+export const INFO_MSG_TIME_DEL = 15000;
+export const DEBUG_INFO_MSG_TIME_DEL = 60000;
+export const DEFAULT_MSG_TIME_DEL = NOTIF_MSG_TIME_DEL;
 export const MAIN_CHANNEL_ID = process.env.CHANNEL_ID || '';
 export const INFO_CHANNEL_ID = process.env.INFO_CHANNEL_ID || '';
 export const ERROR_CHANNEL_ID = process.env.ERROR_CHANNEL_ID || '';

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ bot.on('ready', () => {
             useUnifiedTopology: true,
         }).then(() => {
             sendInfoMessage(bot, 'Connected to MongoDB');
-            localCache.fetch();
+            localCache.fetchAll();
             sendInfoMessage(bot, 'Bot is ready', () => {});
         }).catch((error : Error) => sendErrorMessage(bot, error));
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import mongoose from 'mongoose';
 import { LocalCache } from './caches';
 import { processCommand } from './commands';
 import { PREFIX } from './common/constants';
+import { Lineups } from './models';
 import { sendErrorMessage, sendInfoMessage } from './utils';
 
 // For local development
@@ -32,9 +33,25 @@ bot.on('ready', () => {
             useNewUrlParser: true,
             useUnifiedTopology: true,
         }).then(() => {
-            sendInfoMessage(bot, 'Connected to MongoDB.\nFetching data.');
+            sendInfoMessage(bot, 'Connected to MongoDB. Fetching data.');
             return localCache.fetchAll();
-        }).then(() => {
+        }).then(async (fetchData) => {
+            if (fetchData && fetchData.length) {
+                const { missingLineups, invalidLineups } = fetchData[0];
+
+                if (missingLineups.length > 0) {
+                    await Lineups.create(missingLineups);
+                }
+                
+                if (invalidLineups.length > 0) {
+                    const invalidLineupIds = invalidLineups.map((lineup) => lineup._id);
+                    await Lineups.deleteMany({ _id: { $in: invalidLineupIds } }).exec().then(() => {
+                        const invalidLineupNames = invalidLineups.map((lineup) => lineup.gameName);
+                        const message = `Deleted the following lineup ids: \`${invalidLineupNames.join()}\``;
+                        sendInfoMessage(bot, message, () => {});
+                    });
+                }
+            }
             sendInfoMessage(bot, 'Bot is ready', () => {});
         }).catch((error : Error) => sendErrorMessage(bot, error));
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,9 @@ bot.on('ready', () => {
             useNewUrlParser: true,
             useUnifiedTopology: true,
         }).then(() => {
-            sendInfoMessage(bot, 'Connected to MongoDB');
-            localCache.fetchAll();
+            sendInfoMessage(bot, 'Connected to MongoDB.\nFetching data.');
+            return localCache.fetchAll();
+        }).then(() => {
             sendInfoMessage(bot, 'Bot is ready', () => {});
         }).catch((error : Error) => sendErrorMessage(bot, error));
     }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,2 +1,3 @@
 export { default as Games, Game } from './game.js';
+export { default as Lineups, Lineup } from './lineup.js';
 export { default as Users } from './user.js';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,3 +1,3 @@
 export { default as Games, Game } from './game.js';
-export { default as Lineups, Lineup } from './lineup.js';
+export { default as Lineups, Lineup, ILineup } from './lineup.js';
 export { default as Users } from './user.js';

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,2 +1,2 @@
-export { default as Games } from './game.js';
+export { default as Games, Game } from './game.js';
 export { default as Users } from './user.js';

--- a/src/models/lineup.ts
+++ b/src/models/lineup.ts
@@ -46,19 +46,17 @@ export class Lineup {
     }
 };
 
-
 interface ILineup {
-    game: mongoose.Types.ObjectId;
-    lineup: Array<string>;
+    gameName: string;
+    users: Array<string>;
 };
 
 const lineupSchema = new mongoose.Schema<ILineup>({
     game: {
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Game',
+        type: String,
         required: true,
     },
-    lineup: {
+    users: {
         type: Array<String>,
         required: true,
     },

--- a/src/models/lineup.ts
+++ b/src/models/lineup.ts
@@ -46,7 +46,7 @@ export class Lineup {
     }
 };
 
-interface ILineup {
+export interface ILineup {
     gameName: string;
     users: Array<string>;
 };

--- a/src/models/lineup.ts
+++ b/src/models/lineup.ts
@@ -1,0 +1,67 @@
+import mongoose from 'mongoose';
+
+export class Lineup {
+    private gameName: string;
+    private users: Set<string>;
+
+    constructor(gameName : string, users : Array<string>) {
+        this.gameName = gameName;
+        this.users = new Set(...users);
+    }
+
+    getGameName() : string {
+        return this.gameName;
+    }
+
+    getUsers() : Array<string> {
+        return [...this.users];
+    }
+
+    getUserCount() : number {
+        return this.users.size;
+    }
+
+    hasUser(user : string) : boolean {
+        return this.users.has(user);
+    }
+
+    addUser(newUser : string) : void {
+        this.users.add(newUser);
+    }
+
+    addUsers(newUsers : Array<string>) : void {
+        newUsers.forEach((newUser) => this.users.add(newUser));
+    }
+
+    deleteUser(newUser : string) : void {
+        this.users.delete(newUser);
+    }
+
+    deleteUsers(newUsers : Array<string>) : void {
+        newUsers.forEach((newUser) => this.users.delete(newUser));
+    }
+
+    clear() : void {
+        this.users.clear();
+    }
+};
+
+
+interface ILineup {
+    game: mongoose.Types.ObjectId;
+    lineup: Array<string>;
+};
+
+const lineupSchema = new mongoose.Schema<ILineup>({
+    game: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Game',
+        required: true,
+    },
+    lineup: {
+        type: Array<String>,
+        required: true,
+    },
+});
+
+export default mongoose.model<ILineup>('Lineup', lineupSchema);

--- a/src/models/lineup.ts
+++ b/src/models/lineup.ts
@@ -1,5 +1,10 @@
 import mongoose from 'mongoose';
 
+
+export interface ILineup {
+    gameName: string;
+    users: Array<string>;
+};
 export class Lineup {
     private gameName: string;
     private users: Set<string>;
@@ -7,6 +12,13 @@ export class Lineup {
     constructor(gameName : string, users : Array<string>) {
         this.gameName = gameName;
         this.users = new Set(...users);
+    }
+
+    getLineupWrapper() : ILineup {
+        return {
+            gameName: this.gameName,
+            users: [...this.users],
+        }
     }
 
     getGameName() : string {
@@ -44,11 +56,6 @@ export class Lineup {
     clear() : void {
         this.users.clear();
     }
-};
-
-export interface ILineup {
-    gameName: string;
-    users: Array<string>;
 };
 
 const lineupSchema = new mongoose.Schema<ILineup>({

--- a/src/models/lineup.ts
+++ b/src/models/lineup.ts
@@ -52,7 +52,7 @@ interface ILineup {
 };
 
 const lineupSchema = new mongoose.Schema<ILineup>({
-    game: {
+    gameName: {
         type: String,
         required: true,
     },

--- a/src/models/lineup.ts
+++ b/src/models/lineup.ts
@@ -1,6 +1,5 @@
 import mongoose from 'mongoose';
 
-
 export interface ILineup {
     gameName: string;
     users: Array<string>;

--- a/src/utils/deleteMessage.ts
+++ b/src/utils/deleteMessage.ts
@@ -1,14 +1,14 @@
 import { Message } from "discord.js";
-import { MSG_TIME_DEL } from "../common/constants";
+import { DEFAULT_MSG_TIME_DEL } from "../common/constants";
 
 /**
  * Delete message after a certain amount of time
  * @param sentMessage - message object to be deleted
- * @param timeout - amount of time before deleting message. MSG_TIME_DEL by default (~3s)
+ * @param timeout - amount of time before deleting message. DEFAULT_MSG_TIME_DEL by default (~5s)
  */
 export default function deleteMessage(
     sentMessage : Message,
-    timeout : number = MSG_TIME_DEL,
+    timeout : number = DEFAULT_MSG_TIME_DEL,
 ) {
     sentMessage.delete({ timeout });
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,6 @@
 export { default as deleteMessage } from './deleteMessage';
+export { default as isValidId } from './isValidId';
 export { default as isValidLimit } from './isValidLimit';
-export { default as isValidRole } from './isValidRole';
 export { default as sendErrorMessage } from './sendErrorMessage';
 export { default as sendInfoMessage } from './sendInfoMessage';
 export { default as sendMessage } from './sendMessage';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,6 @@
 export { default as deleteMessage } from './deleteMessage';
-export { default as isValidId } from './isValidId';
 export { default as isValidLimit } from './isValidLimit';
+export { default as isValidRole } from './isValidRole';
 export { default as sendErrorMessage } from './sendErrorMessage';
 export { default as sendInfoMessage } from './sendInfoMessage';
 export { default as sendMessage } from './sendMessage';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 export { default as deleteMessage } from './deleteMessage';
 export { default as isValidLimit } from './isValidLimit';
 export { default as isValidRole } from './isValidRole';
+export { default as isValidUser } from './isValidUser';
 export { default as sendErrorMessage } from './sendErrorMessage';
 export { default as sendInfoMessage } from './sendInfoMessage';
 export { default as sendMessage } from './sendMessage';

--- a/src/utils/isValidId.ts
+++ b/src/utils/isValidId.ts
@@ -1,8 +1,0 @@
-/**
- * Checks whether a string is a valid (discord) id
- * @param id 
- */
-export default function isValidId(id : string) : boolean {
-    const idRegex = /^<@&[0-9]+>$/i; // id format: <@&1234567890>
-    return idRegex.test(id);
-}

--- a/src/utils/isValidId.ts
+++ b/src/utils/isValidId.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether a string is a valid (discord) id
+ * @param id 
+ */
+export default function isValidId(id : string) : boolean {
+    const idRegex = /^<@&[0-9]+>$/i; // id format: <@&1234567890>
+    return idRegex.test(id);
+}

--- a/src/utils/isValidRole.ts
+++ b/src/utils/isValidRole.ts
@@ -1,0 +1,8 @@
+/**
+ * Checks whether the role is valid
+ * @param role 
+ */
+export default function isValidRole(role : string) : boolean {
+    const roleRegex = /^<@&[0-9]+>$/i; // role id format: <@&1234567890>
+    return roleRegex.test(role);
+}

--- a/src/utils/isValidRole.ts
+++ b/src/utils/isValidRole.ts
@@ -1,8 +1,0 @@
-/**
- * Checks whether the role is valid
- * @param role 
- */
-export default function isValidRole(role : string) : boolean {
-    const roleRegex = /^<@&[0-9]+>$/i; // role id format: <@&1234567890>
-    return roleRegex.test(role);
-}

--- a/src/utils/isValidRole.ts
+++ b/src/utils/isValidRole.ts
@@ -1,6 +1,7 @@
 /**
  * Checks whether the role is valid
- * @param role 
+ * Sample id: <@&1234567890>
+ * @param role
  */
 export default function isValidRole(role : string) : boolean {
     const roleRegex = /^<@&[0-9]+>$/i; // role id format: <@&1234567890>

--- a/src/utils/isValidUser.ts
+++ b/src/utils/isValidUser.ts
@@ -1,0 +1,9 @@
+/**
+ * Checks whether the user is valid
+ * Sample id: <@1234567890>
+ * @param user
+ */
+export default function isValidUser(role : string) : boolean {
+    const roleRegex = /^<@[0-9]+>$/i; // user id format: <@1234567890>
+    return roleRegex.test(role);
+}

--- a/src/utils/sendInfoMessage.ts
+++ b/src/utils/sendInfoMessage.ts
@@ -1,9 +1,9 @@
 import { Client, Message, MessageEmbed, TextChannel } from "discord.js";
-import { INFO_CHANNEL_ID, INFO_MSG_TIME_DEL } from "../common/constants";
+import { INFO_CHANNEL_ID, DEBUG_INFO_MSG_TIME_DEL } from "../common/constants";
 import deleteMessage from "./deleteMessage";
 import sendMessage from "./sendMessage";
 
-const defaultOnSuccess = (sentMsg : Message) => deleteMessage(sentMsg, INFO_MSG_TIME_DEL);
+const defaultOnSuccess = (sentMsg : Message) => deleteMessage(sentMsg, DEBUG_INFO_MSG_TIME_DEL);
 
 /**
  * Send an info message

--- a/src/utils/sendMessage.ts
+++ b/src/utils/sendMessage.ts
@@ -1,9 +1,8 @@
 import { DMChannel, Message, NewsChannel, TextChannel } from "discord.js";
-import { MSG_TIME_DEL } from "../common/constants";
 import deleteMessage from "./deleteMessage";
 
 const defaultOnSuccess = (sentMessage : Message) => {
-    deleteMessage(sentMessage, MSG_TIME_DEL);
+    deleteMessage(sentMessage);
 }
 
 const defaultOnError = (error : any) => {
@@ -14,7 +13,8 @@ const defaultOnError = (error : any) => {
  * Send a message to a specified channel
  * @param channel - channel to send to
  * @param content - message to be sent
- * @param onSuccess - optional callback to run when message sends successfully
+ * @param onSuccess - optional callback to run when message sends successfully.
+ * Deletes message after `DEFAULT_MSG_TIME_DEL` (~5s) by default
  * @param onError - optional callback to run when message sends fails. Logs to console by default 
  */
 export default function sendMessage(

--- a/src/utils/sendMessageEmbed.ts
+++ b/src/utils/sendMessageEmbed.ts
@@ -18,12 +18,17 @@ const defaultOnSuccess = (sentMessage : Message) => {
 export default function sendMessageEmbed(
     channel : Channel,
     title : string,
-    message : string,
+    message : string | Object,
     onSuccess : Function = defaultOnSuccess,
     onError ?: Function,
 ) {
-    const messageEmbed = new MessageEmbed()
-        .setTitle(title)
-        .addField('Message', message);
+    const messageEmbed = new MessageEmbed().setTitle(title)
+    if (typeof message === 'string') {
+        messageEmbed.addField('Message', message);
+    } else {
+        Object.entries(message).forEach(([title, contents]) => {
+            messageEmbed.addField(title, contents);
+        })
+    }
     sendMessage(channel as TextChannel, messageEmbed, onSuccess, onError);
 }

--- a/src/utils/sendMessageEmbed.ts
+++ b/src/utils/sendMessageEmbed.ts
@@ -1,10 +1,10 @@
 import { Channel, Message, MessageEmbed, TextChannel } from "discord.js";
-import { MSG_TIME_FULL_DEL } from "../common/constants";
+import { INFO_MSG_TIME_DEL } from "../common/constants";
 import deleteMessage from "./deleteMessage";
 import sendMessage from "./sendMessage";
 
 const defaultOnSuccess = (sentMessage : Message) => {
-    deleteMessage(sentMessage, MSG_TIME_FULL_DEL);
+    deleteMessage(sentMessage, INFO_MSG_TIME_DEL);
 }
 
 /**
@@ -12,7 +12,7 @@ const defaultOnSuccess = (sentMessage : Message) => {
  * @param channel
  * @param title - title for the embedded message
  * @param message - message string to be added to `Message` field
- * @param onSuccess - defaults to deleting the message after `MSG_TIME_FULL_DEL`
+ * @param onSuccess - defaults to deleting the message after `INFO_MSG_TIME_DEL`
  * @param onError
  */
 export default function sendMessageEmbed(


### PR DESCRIPTION
**Changelist**
General Changes:
- [x] Change fetching on startup to fetch lineups and users after games fetch succeeds
- [x] Add help descriptions for lineup commands
- [x] Add util for validating User ids (isValidUser)
- [x] Lineup model
- [x] Persistent lineups

Commands:
- [x] list (all lineups)
- [x] list specified lineups
- [x] join
- [x] join multiple
- [x] join using game name as shorthand
- [x] add
- [x] add multiple
- [x] kick
- [x] kick multiple
- [x] reset all lineups
- [x] reset specified lineups
- [x] invite all joined lineups
- [x] invite specified lineups
- [x] g all joined lineups
- [x] g specified lineups
- [x] leave all lineups
- [x] leave specified lineups

Other refactors:
- [x] Refactor LocalCache class to have its member cache's as private, and the relevant functions to be accessed in the LocalCache class instead (eg. use the LocalCache class somewhat as a view, while the sub cache's as services)
- [x] Add 'game delete' as an alias for 'game remove' command
- [x] Change default message deletion time constants 