### PR TITLE
Use slimmer node image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Use the official Node.js 10 image.
 # https://hub.docker.com/_/node
-FROM node:16
+FROM node:18-bullseye-slim
 # Create and change to the app directory.
 WORKDIR /usr/src/app
 # Copy application dependency manifests to the container image.


### PR DESCRIPTION
Use `node-18-bullseye-slim` version for node image.

Comparison of size of each built images using different node releases.
![image](https://user-images.githubusercontent.com/37403094/200184073-74316b0b-6068-4b42-8182-c6625d9e2ce0.png)
