### PR TITLE
Add expected command formats in certain error messages

### DIFF
--- a/src/commands/game.ts
+++ b/src/commands/game.ts
@@ -20,6 +20,7 @@ function gameList(commandInputs : CommandInputs) {
     if (argsCount !== 0) {
         const content = {
             'Unexpected number of arguments': `Expecting no arguments for \`${PREFIX}${command}\`. Received ${argsCount}.`,
+            'Expected Format/s': '\`.game list\`',
         };
         sendMessage(message.channel, content, 'error', 'Game List');
         return;
@@ -34,15 +35,15 @@ function gameList(commandInputs : CommandInputs) {
 }
 
 /**
- * Function to handle `.game <name>`
+ * Function to handle `.game <game>`
  * Show the info pertaining to a game
  * @param commandInputs - contains the necessary parameters for the command
  */
  function gameDescribe(commandInputs : CommandInputs) {
     const {
-        args, bot, cache, command, message,
+        args, cache, command, message,
     } : {
-        args : Array<string>, bot : Client, cache : LocalCache, command : string, message : Message,
+        args : Array<string>, cache : LocalCache, command : string, message : Message,
     } = commandInputs;
 
     // validation
@@ -50,6 +51,7 @@ function gameList(commandInputs : CommandInputs) {
     if (argsCount !== 1) {
         const content = {
             'Unexpected number of arguments': `Expecting 1 argument for \`${PREFIX}${command}\`. Received ${argsCount}.`,
+            'Expected Format/s': '\`.game <game>\`',
         };
         sendMessage(message.channel, content, 'error', 'Game Describe');
         return;
@@ -86,7 +88,7 @@ function gameList(commandInputs : CommandInputs) {
 }
 
 /**
- * Function to handle `.game add <name> <role> <limit>`
+ * Function to handle `.game add <game> <role> <limit>`
  * Add a game
  * @param commandInputs - contains the necessary parameters for the command
  */
@@ -102,8 +104,9 @@ function gameAdd(commandInputs : CommandInputs) {
     if (argsCount !== 3) {
         const content = {
             'Unexpected number of arguments': `Expecting 3 arguments for \`${PREFIX}${command}\`. Received ${argsCount}.`,
+            'Expected Format/s': '\`.game add <game> <role> <limit>\`',
         };
-        sendMessage(message.channel, content, 'error', 'Game Describe');
+        sendMessage(message.channel, content, 'error', 'Game Add');
         return;
     }
 
@@ -141,7 +144,7 @@ function gameAdd(commandInputs : CommandInputs) {
 }
 
 /**
- * Function to handle `.game remove <name>`
+ * Function to handle `.game remove <game>`
  * Remove a game
  * @param commandInputs - contains the necessary parameters for the command
  */
@@ -157,6 +160,7 @@ function gameRemove(commandInputs : CommandInputs) {
     if (argsCount !== 1) {
         const content = {
             'Unexpected number of arguments': `Expecting 1 argument for \`${PREFIX}${command}\`. Received ${argsCount}.`,
+            'Expected Format/s': '\`.game remove <game>\`',
         };
         sendMessage(message.channel, content, 'error', 'Game Remove');
         return;
@@ -190,7 +194,7 @@ function gameRemove(commandInputs : CommandInputs) {
 }
 
 /**
- * Function to handle `.game edit <name> <role> <?limit>`
+ * Function to handle `.game edit <game> <role> <?limit>`
  * Edit a game's set parameters
  * @param commandInputs - contains the necessary parameters for the command
  */
@@ -206,6 +210,7 @@ function gameEdit(commandInputs : CommandInputs) {
     if (![2, 3].includes(argsCount)) {
         const content = {
             'Unexpected number of arguments': `Expecting 2 or 3 arguments for \`${PREFIX}${command}\`. Received ${argsCount}.`,
+            'Expected Format/s': '\`.game edit <game> <role>\`\n\`.game edit <game> <role> <limit>\`',
         };
         sendMessage(message.channel, content, 'error', 'Game Edit');
         return;

--- a/src/commands/lineup.ts
+++ b/src/commands/lineup.ts
@@ -112,6 +112,7 @@ function lineupAdd(commandInputs : CommandInputs) {
     if (argsCount < 2) {
         const content = {
             'Unexpected number of arguments': `Expecting at least 2 arguments for \`${PREFIX}${command}\`. Received ${argsCount}.`,
+            'Expected Format/s': '\`.lineup add <game> <user id/s>\`',
         };
         sendMessage(message.channel, content, 'error', 'Lineup Add');
         return;
@@ -282,6 +283,7 @@ function lineupKick(commandInputs : CommandInputs) {
     if (argsCount < 2) {
         const content = {
             'Unexpected number of arguments': `Expecting at least 2 arguments for \`${PREFIX}${command}\`. Received ${argsCount}.`,
+            'Expected Format/s': '\`.lineup kick <game> <user id>\`',
         };
         sendMessage(message.channel, content, 'error', 'Lineup Kick');
         return;

--- a/src/commands/user.ts
+++ b/src/commands/user.ts
@@ -21,6 +21,7 @@ import { CommandInputs } from './processCommand.js';
     if (argsCount > 0) {
         const content = {
             'Unexpected number of arguments': `Expecting 0 arguments for \`${PREFIX}${command}\`. Received ${argsCount}.`,
+            'Expected Format/s': '\`.user view\`',
         };
         sendMessage(message.channel, content, 'error', 'User View');
         return;
@@ -52,6 +53,7 @@ function userSave(commandInputs : CommandInputs) {
     if (argsCount < 1) {
         const content = {
             'Unexpected number of arguments': `Expecting at least 1 argument for \`${PREFIX}${command}\`. Received ${argsCount}.`,
+            'Expected Format/s': '\`.user save <game/s>\`',
         };
         sendMessage(message.channel, content, 'error', 'User Save');
         return;
@@ -122,6 +124,7 @@ const {
     if (argsCount < 1) {
         const content = {
             'Unexpected number of arguments': `Expecting at least 1 argument for \`${PREFIX}${command}\`. Received ${argsCount}.`,
+            'Expected Format/s': '\`.user remove <game/s>\`',
         };
         sendMessage(message.channel, content, 'error', 'User Remove');
         return;
@@ -192,6 +195,7 @@ const {
     if (argsCount > 0) {
         const content = {
             'Unexpected number of arguments': `Expecting 0 arguments for \`${PREFIX}${command}\`. Received ${argsCount}.`,
+            'Expected Format/s': '\`.user clear\`',
         };
         sendMessage(message.channel, content, 'error', 'User Clear');
         return;


### PR DESCRIPTION
Prerequisite PR to be merged: #63 

Send the expected format of the command for error messages with the wrong arguments.
- [x] Game commands
- [x] Lineup commands
- [x] User commands